### PR TITLE
fix: fallback to song metadata for video detection when video element…

### DIFF
--- a/src/modules/lyrics/lyrics.ts
+++ b/src/modules/lyrics/lyrics.ts
@@ -84,7 +84,6 @@ export async function createLyrics(detail: PlayerDetails, signal: AbortSignal): 
   let videoId = detail.videoId;
   let duration = Number(detail.duration);
   const audioTrackData = detail.audioTrackData;
-  const isMusicVideo = detail.contentRect.width !== 0 && detail.contentRect.height !== 0;
 
   if (!videoId) {
     log(SERVER_ERROR_LOG, "Invalid video id");
@@ -97,6 +96,9 @@ export async function createLyrics(detail: PlayerDetails, signal: AbortSignal): 
     // We should get recalled if we were executed without a valid song/artist and aren't able to get lyrics
 
     let matchingSong = await getSongMetadata(videoId, 1, signal);
+    let isMusicVideo =
+      (detail.contentRect.width !== 0 && detail.contentRect.height !== 0) ||
+      matchingSong?.isVideo === true;
     let swappedVideoId = false;
     let isAVSwitch =
       (matchingSong &&
@@ -137,6 +139,7 @@ export async function createLyrics(detail: PlayerDetails, signal: AbortSignal): 
     if (matchingSong) {
       song = matchingSong.title;
       artist = matchingSong.artist || artist;
+      isMusicVideo = isMusicVideo || matchingSong.isVideo === true;
 
       if (isMusicVideo && matchingSong.counterpartVideoId && matchingSong.segmentMap) {
         log("Switching VideoId to Audio Id");


### PR DESCRIPTION
# Description

When browser extensions like "Music Mode for YouTube" hide or collapse the `<video>` DOM element on YouTube Music, its dimensions become `0x0`. Previously, `isMusicVideo` relied solely on checking DOM dimensions (`contentRect.width !== 0 && contentRect.height !== 0`).

As a result, when the video element was hidden by third-party extensions, Better Lyrics incorrectly treated the track as non-video and skipped swapping the `videoId` to its audio counterpart (`counterpartVideoId`), causing lyric fetching to get stuck on "searching for lyrics".

This fix adds a fallback to `matchingSong.isVideo` (parsed directly from YouTube's API metadata) so video detection remains accurate even when the DOM video element is hidden.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## Related Issue (if applicable)

Fixes issue with Music Mode for YouTube hiding video elements.

## Checklist

- [x] I have performed a self-review of my code
- [ ] Will this be part of a product update? If yes, please write one phrase about this update.