### PR TITLE
feat: add Gemini translation support

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -300,6 +300,62 @@
     "message": "Translation language",
     "description": "Translation language setting label"
   },
+  "options_language_translationProvider": {
+    "message": "Translation service",
+    "description": "Dropdown label to select which translation engine to use"
+  },
+  "options_language_googleTranslate": {
+    "message": "Google Translate",
+    "description": "Google Translate provider option"
+  },
+  "options_language_geminiApi": {
+    "message": "Gemini API",
+    "description": "Gemini API translation provider option"
+  },
+  "options_language_geminiApiSettings": {
+    "message": "Gemini API Settings",
+    "description": "Label for Gemini API settings button or collapsible container"
+  },
+  "options_language_geminiApiKeyPlaceholder": {
+    "message": "Enter your Gemini API key...",
+    "description": "Placeholder in the input field for Gemini API key"
+  },
+  "options_language_manageModelFallback": {
+    "message": "Manage Model Fallback",
+    "description": "Label for the settings trigger/modal to manage fallback options for Gemini models"
+  },
+  "options_language_clearTranslationCache": {
+    "message": "Clear Translation Cache",
+    "description": "Button label to clear cached Gemini/API translations"
+  },
+  "options_language_modelFallbackSequence": {
+    "message": "Model Fallback Sequence",
+    "description": "Title of the fallback sequence configuration popup or section"
+  },
+  "options_language_dragToReorder": {
+    "message": "Drag to reorder model preference. Topmost available model will be attempted first.",
+    "description": "Instruction label inside the model fallback modal"
+  },
+  "options_language_translationCacheCleared": {
+    "message": "Translation cache cleared successfully",
+    "description": "Success message when user clears local translation cache"
+  },
+  "options_language_sequence": {
+    "message": "Sequence",
+    "description": "Label prefix displaying the order of attempted models"
+  },
+  "options_language_translationMode": {
+    "message": "Translation mode",
+    "description": "Setting label to choose between translation modes"
+  },
+  "options_language_translationModeSpeed": {
+    "message": "Speed",
+    "description": "Speed mode translation option description"
+  },
+  "options_language_translationModeQuality": {
+    "message": "Quality",
+    "description": "Quality mode translation option description"
+  },
 
   "options_sources_title": {
     "message": "Lyric Source Preference",
@@ -1057,6 +1113,14 @@
   "lyrics_source": {
     "message": "Source: ",
     "description": "Lyrics source label"
+  },
+  "lyrics_translationSource": {
+    "message": "Translation: ",
+    "description": "Label for translation source in footer (e.g. Translation: )"
+  },
+  "lyrics_translationErrorGemini": {
+    "message": "Gemini API translation error, please try again later",
+    "description": "Error message shown in the translation source capsule when all Gemini models fail"
   },
   "lyrics_searchOnGenius": {
     "message": "Search on Genius",

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -308,6 +308,62 @@
     "message": "Translation language",
     "description": "Translation language setting label"
   },
+  "options_language_translationProvider": {
+    "message": "Translation service",
+    "description": "Dropdown label to select which translation engine to use"
+  },
+  "options_language_googleTranslate": {
+    "message": "Google Translate",
+    "description": "Google Translate provider option"
+  },
+  "options_language_geminiApi": {
+    "message": "Gemini API",
+    "description": "Gemini API translation provider option"
+  },
+  "options_language_geminiApiSettings": {
+    "message": "Gemini API Settings",
+    "description": "Label for Gemini API settings button or collapsible container"
+  },
+  "options_language_geminiApiKeyPlaceholder": {
+    "message": "Enter your Gemini API key...",
+    "description": "Placeholder in the input field for Gemini API key"
+  },
+  "options_language_manageModelFallback": {
+    "message": "Manage Model Fallback",
+    "description": "Label for the settings trigger/modal to manage fallback options for Gemini models"
+  },
+  "options_language_clearTranslationCache": {
+    "message": "Clear Translation Cache",
+    "description": "Button label to clear cached Gemini/API translations"
+  },
+  "options_language_modelFallbackSequence": {
+    "message": "Model Fallback Sequence",
+    "description": "Title of the fallback sequence configuration popup or section"
+  },
+  "options_language_dragToReorder": {
+    "message": "Drag to reorder model preference. Topmost available model will be attempted first.",
+    "description": "Instruction label inside the model fallback modal"
+  },
+  "options_language_translationCacheCleared": {
+    "message": "Translation cache cleared successfully",
+    "description": "Success message when user clears local translation cache"
+  },
+  "options_language_sequence": {
+    "message": "Sequence",
+    "description": "Label prefix displaying the order of attempted models"
+  },
+  "options_language_translationMode": {
+    "message": "Translation mode",
+    "description": "Setting label to choose between translation modes"
+  },
+  "options_language_translationModeSpeed": {
+    "message": "Speed",
+    "description": "Speed mode translation option description"
+  },
+  "options_language_translationModeQuality": {
+    "message": "Quality",
+    "description": "Quality mode translation option description"
+  },
 
   "options_sources_title": {
     "message": "Lyric Source Preference",
@@ -1069,6 +1125,14 @@
   "lyrics_source": {
     "message": "Source: ",
     "description": "Lyrics source label"
+  },
+  "lyrics_translationSource": {
+    "message": "Translation: ",
+    "description": "Label for translation source in footer (e.g. Translation: )"
+  },
+  "lyrics_translationErrorGemini": {
+    "message": "Gemini API translation error, please try again later",
+    "description": "Error message shown in the translation source capsule when all Gemini models fail"
   },
   "lyrics_searchOnGenius": {
     "message": "Search on Genius",

--- a/src/core/appState.ts
+++ b/src/core/appState.ts
@@ -39,6 +39,10 @@ interface AppStateType {
   lastLoadedVideoId: string | null;
   lyricAbortController: AbortController | null;
   isTranslateEnabled: boolean;
+  translationProvider: "google" | "gemini";
+  geminiApiKey: string;
+  geminiModelFallback: string[];
+  geminiTranslationMode: "speed" | "quality";
   isRomanizationEnabled: boolean;
   romanizationDisabledLanguages: string[];
   translationDisabledLanguages: string[];
@@ -82,6 +86,10 @@ export const AppState: AppStateType = {
   lastLoadedVideoId: null,
   lyricAbortController: null,
   isTranslateEnabled: false,
+  translationProvider: "google",
+  geminiApiKey: "",
+  geminiModelFallback: ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"],
+  geminiTranslationMode: "speed",
   isRomanizationEnabled: false,
   romanizationDisabledLanguages: [],
   translationDisabledLanguages: [],

--- a/src/core/appState.ts
+++ b/src/core/appState.ts
@@ -43,6 +43,10 @@ interface AppStateType {
   lastLoadedVideoId: string | null;
   lyricAbortController: AbortController | null;
   isTranslateEnabled: boolean;
+  translationProvider: "google" | "gemini";
+  geminiApiKey: string;
+  geminiModelFallback: string[];
+  geminiTranslationMode: "speed" | "quality";
   isRomanizationEnabled: boolean;
   romanizationDisabledLanguages: string[];
   translationDisabledLanguages: string[];
@@ -89,6 +93,10 @@ export const AppState: AppStateType = {
   lastLoadedVideoId: null,
   lyricAbortController: null,
   isTranslateEnabled: false,
+  translationProvider: "google",
+  geminiApiKey: "",
+  geminiModelFallback: ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"],
+  geminiTranslationMode: "speed",
   isRomanizationEnabled: false,
   romanizationDisabledLanguages: [],
   translationDisabledLanguages: [],

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -88,10 +88,11 @@ export function t(key: string, substitutions?: string | string[]): string {
   return message || key;
 }
 
-export function getLanguageDisplayName(langCode: string): string {
+export function getLanguageDisplayName(langCode: string, locale?: string): string {
   try {
     const displayCode = DISPLAY_CODE_MAP[langCode] ?? langCode;
-    const displayNames = new Intl.DisplayNames([navigator.language], { type: "language" });
+    const targetLocale = locale || (typeof navigator !== "undefined" ? navigator.language : "en");
+    const displayNames = new Intl.DisplayNames([targetLocale], { type: "language" });
     return displayNames.of(displayCode) ?? langCode;
   } catch (e) {
     console.warn(`${LOG_PREFIX} Failed to get display name for "${langCode}":`, e);

--- a/src/core/i18n.ts
+++ b/src/core/i18n.ts
@@ -88,10 +88,11 @@ export function t(key: string, substitutions?: string | string[]): string {
   return message || key;
 }
 
-export function getLanguageDisplayName(langCode: string): string {
+export function getLanguageDisplayName(langCode: string, locale?: string): string {
   try {
     const displayCode = DISPLAY_CODE_MAP[langCode] ?? langCode;
-    const displayNames = new Intl.DisplayNames([navigator.language], { type: "language" });
+    const targetLocale = locale || (typeof navigator !== "undefined" ? navigator.language : "en");
+    const displayNames = new Intl.DisplayNames([targetLocale], { type: "language" });
     return displayNames.of(displayCode) ?? langCode;
   } catch (e) {
     warnCore(`Failed to get display name for "${langCode}":`, e);

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -276,7 +276,7 @@ export async function purgeExpiredKeys(): Promise<void> {
     const keysToRemove: string[] = [];
 
     Object.keys(result).forEach(key => {
-      if (key.startsWith("blyrics_")) {
+      if (key.startsWith("blyrics_") || key.startsWith("gemini_")) {
         const item = result[key] as TransientStorageItem;
         if (item.expiry && now >= item.expiry) {
           keysToRemove.push(key);

--- a/src/core/storage.ts
+++ b/src/core/storage.ts
@@ -295,7 +295,7 @@ export async function purgeExpiredKeys(): Promise<void> {
     const keysToRemove: string[] = [];
 
     Object.keys(result).forEach(key => {
-      if (key.startsWith("blyrics_")) {
+      if (key.startsWith("blyrics_") || key.startsWith("gemini_")) {
         const item = result[key] as TransientStorageItem;
         if (item.expiry && now >= item.expiry) {
           keysToRemove.push(key);

--- a/src/modules/lyrics/geminiTranslation.ts
+++ b/src/modules/lyrics/geminiTranslation.ts
@@ -1,0 +1,145 @@
+import { TRANSLATION_ERROR_LOG, LYRICS_CACHE_TTL_MS } from "@constants";
+import { AppState } from "@core/appState";
+import { getLanguageDisplayName } from "@core/i18n";
+import { getTransientStorage, setTransientStorage } from "@core/storage";
+import { log } from "@utils";
+import type { BatchRequest, BatchTranslationResponse, TranslationResult } from "./translation";
+
+/**
+ * Translates a batch of lyric lines using Gemini models with model fallback.
+ */
+export async function translateBatchGemini(request: BatchRequest): Promise<BatchTranslationResponse> {
+  const { lines, targetLanguage, signal } = request;
+  if (!targetLanguage || lines.length === 0) {
+    return { results: lines.map(() => null), detectedLanguage: "" };
+  }
+
+  const videoId = AppState.lastLoadedVideoId;
+  const lineCount = lines.length;
+  const models =
+    AppState.geminiModelFallback && AppState.geminiModelFallback.length > 0
+      ? AppState.geminiModelFallback
+      : ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"];
+  const apiKey = AppState.geminiApiKey;
+  const lyricSource = AppState.currentProviderKey || "unknown";
+
+  if (!apiKey) {
+    log(TRANSLATION_ERROR_LOG, "Gemini API key is missing");
+    return { results: lines.map(() => null), detectedLanguage: "" };
+  }
+
+  const results: (TranslationResult | null)[] = new Array(lines.length).fill(null);
+
+  for (const model of models) {
+    const cacheKey = `gemini_${lyricSource}_${model}_${videoId}_${targetLanguage}_${lineCount}`;
+    try {
+      const cachedData = await getTransientStorage(cacheKey);
+      if (cachedData) {
+        const cachedLines = JSON.parse(cachedData);
+        if (Array.isArray(cachedLines) && cachedLines.length === lineCount) {
+          cachedLines.forEach((t, i) => {
+            results[i] = { originalLanguage: "auto", translatedText: t };
+          });
+          return { results, detectedLanguage: "auto", translationSource: model };
+        }
+      }
+    } catch (e) {
+      log(TRANSLATION_ERROR_LOG, "Cache read error", e);
+    }
+  }
+
+  const targetLanguageName = getLanguageDisplayName(targetLanguage, "en");
+  const prompt = `Translate the following lyrics to ${targetLanguageName}. Here are the lyrics:\n\n${JSON.stringify(lines)}`;
+
+  for (const model of models) {
+    try {
+      const isQualityMode = AppState.geminiTranslationMode === "quality";
+      const useQuality = isQualityMode;
+
+      const systemInstruction = useQuality
+        ? `Translate the input JSON array of lyrics to the target language. Return a JSON array of translated strings matching the input length.`
+        : `You are a translation API for a music player feature.
+
+The user is actively listening to music and needs synchronized lyric translations displayed in real time.
+
+Output format: Return a JSON array of translated strings matching the input length.
+Example input: ["Hello", "World"]
+Example output: ["你好", "世界"]
+
+Rules:
+1. Never merge multiple lines into one
+2. Never split one line into multiple lines
+3. Maintain the exact same number of lines
+4. If text is empty or just symbols, return it unchanged
+`;
+
+      const payload = {
+        contents: [{ role: "user", parts: [{ text: prompt }] }],
+        systemInstruction: {
+          parts: [
+            {
+              text: systemInstruction,
+            },
+          ],
+        },
+        generationConfig: {
+          responseMimeType: "application/json",
+          responseSchema: {
+            type: "ARRAY",
+            items: { type: "STRING" },
+            minItems: Math.min(2, lineCount),
+          },
+          thinkingConfig: {
+            thinkingLevel: useQuality ? "medium" : "minimal",
+          },
+        },
+      };
+
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-goog-api-key": apiKey,
+        },
+        body: JSON.stringify(payload),
+        signal,
+      });
+
+      if (!response.ok) {
+        log(TRANSLATION_ERROR_LOG, `Gemini API error with model ${model}: ${response.status}`);
+        continue;
+      }
+
+      const data = await response.json();
+      const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+
+      if (text) {
+        let parsedLines: string[];
+        try {
+          parsedLines = JSON.parse(text);
+        } catch (e) {
+          log(TRANSLATION_ERROR_LOG, `Failed to parse Gemini response for model ${model}`, e);
+          continue;
+        }
+
+        if (Array.isArray(parsedLines) && parsedLines.length === lineCount) {
+          const cacheKey = `gemini_${lyricSource}_${model}_${videoId}_${targetLanguage}_${lineCount}`;
+          await setTransientStorage(cacheKey, JSON.stringify(parsedLines), LYRICS_CACHE_TTL_MS);
+
+          parsedLines.forEach((t, i) => {
+            results[i] = { originalLanguage: "auto", translatedText: t };
+          });
+          return { results, detectedLanguage: "auto", translationSource: model };
+        } else {
+          log(TRANSLATION_ERROR_LOG, `Model ${model} returned ${parsedLines.length} lines, expected ${lineCount}`);
+        }
+      }
+    } catch (error) {
+      if ((error as Error).name === "AbortError") throw error;
+      log(TRANSLATION_ERROR_LOG, `Gemini translation failed with model ${model}`, error);
+    }
+  }
+
+  return { results, detectedLanguage: "auto", translationError: true };
+}

--- a/src/modules/lyrics/geminiTranslation.ts
+++ b/src/modules/lyrics/geminiTranslation.ts
@@ -1,0 +1,145 @@
+import { TRANSLATION_ERROR_LOG, LYRICS_CACHE_TTL_MS } from "@constants";
+import { AppState } from "@core/appState";
+import { getLanguageDisplayName } from "@core/i18n";
+import { logCore } from "@core/logger";
+import { getTransientStorage, setTransientStorage } from "@core/storage";
+import type { BatchRequest, BatchTranslationResponse, TranslationResult } from "./translation";
+
+/**
+ * Translates a batch of lyric lines using Gemini models with model fallback.
+ */
+export async function translateBatchGemini(request: BatchRequest): Promise<BatchTranslationResponse> {
+  const { lines, targetLanguage, signal } = request;
+  if (!targetLanguage || lines.length === 0) {
+    return { results: lines.map(() => null), detectedLanguage: "" };
+  }
+
+  const videoId = AppState.lastLoadedVideoId;
+  const lineCount = lines.length;
+  const models =
+    AppState.geminiModelFallback && AppState.geminiModelFallback.length > 0
+      ? AppState.geminiModelFallback
+      : ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"];
+  const apiKey = AppState.geminiApiKey;
+  const lyricSource = AppState.currentProviderKey || "unknown";
+
+  if (!apiKey) {
+    logCore(TRANSLATION_ERROR_LOG, "Gemini API key is missing");
+    return { results: lines.map(() => null), detectedLanguage: "" };
+  }
+
+  const results: (TranslationResult | null)[] = new Array(lines.length).fill(null);
+
+  for (const model of models) {
+    const cacheKey = `gemini_${lyricSource}_${model}_${videoId}_${targetLanguage}_${lineCount}`;
+    try {
+      const cachedData = await getTransientStorage(cacheKey);
+      if (cachedData) {
+        const cachedLines = JSON.parse(cachedData);
+        if (Array.isArray(cachedLines) && cachedLines.length === lineCount) {
+          cachedLines.forEach((t, i) => {
+            results[i] = { originalLanguage: "auto", translatedText: t };
+          });
+          return { results, detectedLanguage: "auto", translationSource: model };
+        }
+      }
+    } catch (e) {
+      logCore(TRANSLATION_ERROR_LOG, "Cache read error", e);
+    }
+  }
+
+  const targetLanguageName = getLanguageDisplayName(targetLanguage, "en");
+  const prompt = `Translate the following lyrics to ${targetLanguageName}. Here are the lyrics:\n\n${JSON.stringify(lines)}`;
+
+  for (const model of models) {
+    try {
+      const isQualityMode = AppState.geminiTranslationMode === "quality";
+      const useQuality = isQualityMode;
+
+      const systemInstruction = useQuality
+        ? `Translate the input JSON array of lyrics to the target language. Return a JSON array of translated strings matching the input length.`
+        : `You are a translation API for a music player feature.
+
+The user is actively listening to music and needs synchronized lyric translations displayed in real time.
+
+Output format: Return a JSON array of translated strings matching the input length.
+Example input: ["Hello", "World"]
+Example output: ["你好", "世界"]
+
+Rules:
+1. Never merge multiple lines into one
+2. Never split one line into multiple lines
+3. Maintain the exact same number of lines
+4. If text is empty or just symbols, return it unchanged
+`;
+
+      const payload = {
+        contents: [{ role: "user", parts: [{ text: prompt }] }],
+        systemInstruction: {
+          parts: [
+            {
+              text: systemInstruction,
+            },
+          ],
+        },
+        generationConfig: {
+          responseMimeType: "application/json",
+          responseSchema: {
+            type: "ARRAY",
+            items: { type: "STRING" },
+            minItems: Math.min(2, lineCount),
+          },
+          thinkingConfig: {
+            thinkingLevel: useQuality ? "medium" : "minimal",
+          },
+        },
+      };
+
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent`;
+      const response = await fetch(url, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "x-goog-api-key": apiKey,
+        },
+        body: JSON.stringify(payload),
+        signal,
+      });
+
+      if (!response.ok) {
+        logCore(TRANSLATION_ERROR_LOG, `Gemini API error with model ${model}: ${response.status}`);
+        continue;
+      }
+
+      const data = await response.json();
+      const text = data.candidates?.[0]?.content?.parts?.[0]?.text;
+
+      if (text) {
+        let parsedLines: string[];
+        try {
+          parsedLines = JSON.parse(text);
+        } catch (e) {
+          logCore(TRANSLATION_ERROR_LOG, `Failed to parse Gemini response for model ${model}`, e);
+          continue;
+        }
+
+        if (Array.isArray(parsedLines) && parsedLines.length === lineCount) {
+          const cacheKey = `gemini_${lyricSource}_${model}_${videoId}_${targetLanguage}_${lineCount}`;
+          await setTransientStorage(cacheKey, JSON.stringify(parsedLines), LYRICS_CACHE_TTL_MS);
+
+          parsedLines.forEach((t, i) => {
+            results[i] = { originalLanguage: "auto", translatedText: t };
+          });
+          return { results, detectedLanguage: "auto", translationSource: model };
+        } else {
+          logCore(TRANSLATION_ERROR_LOG, `Model ${model} returned ${parsedLines.length} lines, expected ${lineCount}`);
+        }
+      }
+    } catch (error) {
+      if ((error as Error).name === "AbortError") throw error;
+      logCore(TRANSLATION_ERROR_LOG, `Gemini translation failed with model ${model}`, error);
+    }
+  }
+
+  return { results, detectedLanguage: "auto", translationError: true };
+}

--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -44,6 +44,7 @@ import {
   flushLoader,
   renderLoader,
   setExtraHeight,
+  updateTranslationSource,
 } from "@modules/ui/dom";
 import { disableNativeLyricsFocus } from "@modules/ui/nativeLyricsFocus";
 import { getRelativeLayoutBounds, langCodesMatch, languageMatchesAny, log } from "@utils";
@@ -743,6 +744,7 @@ async function processBatchTranslationsAndRomanizations(
   // 1. Identify what needs to be translated/romanized
   lyrics.forEach((item, index) => {
     if (item.isInstrumental) return;
+    if (item.words === t("lyrics_notFound")) return;
 
     const lineData = linesData[index];
     const lyricElement = lineData.lyricElement;
@@ -851,6 +853,12 @@ async function processBatchTranslationsAndRomanizations(
         });
         if (isStale()) return;
 
+        if (response.translationSource) {
+          updateTranslationSource(response.translationSource);
+        } else if (response.translationError) {
+          updateTranslationSource("error");
+        }
+
         if (!sourceLanguage && response.detectedLanguage) {
           sourceLanguage = response.detectedLanguage;
           log(LOG_PREFIX, "Determined language via translation batch: " + sourceLanguage);
@@ -861,7 +869,10 @@ async function processBatchTranslationsAndRomanizations(
         response.results.forEach((result, i) => {
           if (result) {
             const originalIndex = translationBatch[i].index;
-            injectTranslation(linesData[originalIndex].lyricElement, result.translatedText);
+            const originalText = translationBatch[i].text;
+            if (!isSameText(result.translatedText, originalText)) {
+              injectTranslation(linesData[originalIndex].lyricElement, result.translatedText);
+            }
           }
         });
         lyricsElementAdded();

--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -18,7 +18,15 @@ import {
   romanizeBatch,
   translateBatch,
 } from "@modules/lyrics/translation";
-import { addFooter, addNoLyricsButton, cleanup, createLyricsWrapper, flushLoader, renderLoader } from "@modules/ui/dom";
+import {
+  addFooter,
+  addNoLyricsButton,
+  cleanup,
+  createLyricsWrapper,
+  flushLoader,
+  renderLoader,
+  updateTranslationSource,
+} from "@modules/ui/dom";
 import { lyricsElementAdded, mainView } from "@modules/ui/mainLyricsView";
 import { disableNativeLyricsFocus } from "@modules/ui/nativeLyricsFocus";
 import { publishPictureInPictureLyrics } from "@modules/ui/pictureInPicture/lyricsPublisher";
@@ -226,6 +234,7 @@ async function processBatchTranslationsAndRomanizations(
   // 1. Identify what needs to be translated/romanized
   lyrics.forEach((item, index) => {
     if (item.isInstrumental) return;
+    if (item.words === t("lyrics_notFound")) return;
 
     const lineData = linesData[index];
     const lyricElement = lineData.lyricElement;
@@ -346,6 +355,12 @@ async function processBatchTranslationsAndRomanizations(
         });
         if (isStale()) return;
 
+        if (response.translationSource) {
+          updateTranslationSource(response.translationSource);
+        } else if (response.translationError) {
+          updateTranslationSource("error");
+        }
+
         if (!sourceLanguage && response.detectedLanguage) {
           sourceLanguage = response.detectedLanguage;
           logCore("Determined language via translation batch: " + sourceLanguage);
@@ -356,8 +371,11 @@ async function processBatchTranslationsAndRomanizations(
         response.results.forEach((result, i) => {
           if (result) {
             const originalIndex = translationBatch[i].index;
-            injectTranslation(doc, linesData[originalIndex].lyricElement, result.translatedText);
-            recordLyricDecoration(originalIndex, { translation: result.translatedText });
+            const originalText = translationBatch[i].text;
+            if (!isSameText(result.translatedText, originalText)) {
+              injectTranslation(doc, linesData[originalIndex].lyricElement, result.translatedText);
+              recordLyricDecoration(originalIndex, { translation: result.translatedText });
+            }
           }
         });
         lyricsElementAdded();

--- a/src/modules/lyrics/injectLyrics.ts
+++ b/src/modules/lyrics/injectLyrics.ts
@@ -195,7 +195,7 @@ function injectLyrics(
     addNoLyricsButton(data.song, data.artist, data.album, data.duration, data.videoId);
   }
 
-  void processBatchTranslationsAndRomanizations(doc, data, lines, isStale, signal);
+  void processBatchTranslationsAndRomanizations(doc, data, lines, isStale, keepLoaderVisible, signal);
 
   if (data.segmentMap) {
     applySegmentMapToLyrics(lyricsData, lines, data.segmentMap);
@@ -218,12 +218,15 @@ async function processBatchTranslationsAndRomanizations(
   data: LyricSourceResultWithMeta,
   linesData: readonly LineData[],
   isStale: () => boolean,
+  keepLoaderVisible = false,
   signal?: AbortSignal
 ): Promise<void> {
   const lyrics = data.lyrics!;
   const targetTranslationLang = AppState.translationLanguage;
   const isRomanizationEnabled = AppState.isRomanizationEnabled;
   const isTranslateEnabled = AppState.isTranslateEnabled;
+  const isGeminiProvider = AppState.translationProvider === "gemini";
+  const skipTranslationBatch = keepLoaderVisible && isGeminiProvider;
 
   const romanizationBatch: { index: number; text: string }[] = [];
   const translationBatch: { index: number; text: string }[] = [];
@@ -300,7 +303,7 @@ async function processBatchTranslationsAndRomanizations(
         injectTranslation(doc, lyricElement, translationResult);
         recordLyricDecoration(index, { translation: translationResult });
         didInjectCachedContent = true;
-      } else if (sourceLanguage !== targetTranslationLang || containsNonLatin(item.words) || !sourceLanguage) {
+      } else if (!skipTranslationBatch && (sourceLanguage !== targetTranslationLang || containsNonLatin(item.words) || !sourceLanguage)) {
         translationBatch.push({ index, text: item.words });
       }
     }

--- a/src/modules/lyrics/lyrics.ts
+++ b/src/modules/lyrics/lyrics.ts
@@ -15,7 +15,7 @@ import type { Lyric, LyricSourceResult, ProviderParameters } from "./providers/s
 import { getLyrics, newSourceMap, providerPriority } from "./providers/shared";
 import type { YTLyricSourceResult } from "./providers/yt";
 import { getSongAlbum, getSongMetadata, type SegmentMap } from "./requestSniffer/requestSniffer";
-import { clearCache as clearTranslationCache } from "./translation";
+import { clearMemoryTranslationCache } from "./translation";
 import { animEngineState } from "@modules/ui/animationEngine";
 
 const hideInstrumentalOnly = registerThemeSetting("blyrics-hide-instrumental-only", false, true);
@@ -123,7 +123,7 @@ export async function createLyrics(detail: PlayerDetails, signal: AbortSignal): 
       log("Not Switching between audio/video", isAVSwitch, segmentMap);
       renderLoader();
       shouldCleanupLoader = true;
-      clearTranslationCache();
+      clearMemoryTranslationCache();
       matchingSong = await getSongMetadata(videoId, 250, signal);
       segmentMap = matchingSong?.segmentMap || null;
       AppState.areLyricsLoaded = false;

--- a/src/modules/lyrics/lyrics.ts
+++ b/src/modules/lyrics/lyrics.ts
@@ -15,7 +15,7 @@ import { getLyrics, newSourceMap, providerPriority } from "./providers/shared";
 import { awaitUnifiedStream } from "./providers/unified";
 import type { YTLyricSourceResult } from "./providers/yt";
 import { getSongAlbum, getSongMetadata, type SegmentMap } from "./requestSniffer/requestSniffer";
-import { clearCache as clearTranslationCache } from "./translation";
+import { clearMemoryTranslationCache } from "./translation";
 import { mainView } from "@modules/ui/mainLyricsView";
 import { resetPlaybackClock, resumeAllAutoscroll } from "@braccato/core";
 import { registerThemeSetting } from "@braccato/core/themeSettings";
@@ -215,7 +215,7 @@ export async function createLyrics(detail: PlayerDetails, signal: AbortSignal): 
       logCore("Not Switching between audio/video", isAVSwitch, segmentMap);
       renderLoader();
       shouldCleanupLoader = true;
-      clearTranslationCache();
+      clearMemoryTranslationCache();
       matchingSong = await getSongMetadata(videoId, 250, signal);
       segmentMap = matchingSong?.segmentMap || null;
       AppState.areLyricsLoaded = false;

--- a/src/modules/lyrics/translation.ts
+++ b/src/modules/lyrics/translation.ts
@@ -297,9 +297,7 @@ export function clearCache(): void {
   cache.translation.clear();
   try {
     chrome.storage.local.get(null).then(items => {
-      const keysToRemove = Object.keys(items).filter(
-        key => key.startsWith("gemini_")
-      );
+      const keysToRemove = Object.keys(items).filter(key => key.startsWith("gemini_"));
       if (keysToRemove.length > 0) {
         chrome.storage.local.remove(keysToRemove);
       }
@@ -322,9 +320,7 @@ export async function clearTranslationCache(): Promise<void> {
   cache.translation.clear();
   try {
     const items = await chrome.storage.local.get(null);
-    const keysToRemove = Object.keys(items).filter(
-      key => key.startsWith("gemini_")
-    );
+    const keysToRemove = Object.keys(items).filter(key => key.startsWith("gemini_"));
     if (keysToRemove.length > 0) {
       await chrome.storage.local.remove(keysToRemove);
     }

--- a/src/modules/lyrics/translation.ts
+++ b/src/modules/lyrics/translation.ts
@@ -332,3 +332,8 @@ export async function clearTranslationCache(): Promise<void> {
     log(TRANSLATION_ERROR_LOG, "Error clearing local cache", e);
   }
 }
+
+export function clearMemoryTranslationCache(): void {
+  cache.romanization.clear();
+  cache.translation.clear();
+}

--- a/src/modules/lyrics/translation.ts
+++ b/src/modules/lyrics/translation.ts
@@ -1,7 +1,9 @@
 import { TRANSLATE_IN_ROMAJI, TRANSLATE_LYRICS_URL, TRANSLATION_ERROR_LOG } from "@constants";
-import { log } from "@utils";
+import { AppState } from "@core/appState";
+import { langCodesMatch, log } from "@utils";
+import { translateBatchGemini } from "./geminiTranslation";
 
-interface TranslationResult {
+export interface TranslationResult {
   originalLanguage: string;
   translatedText: string;
 }
@@ -16,16 +18,18 @@ const cache: TranslationCache = {
   translation: new Map(),
 };
 
-interface BatchRequest {
+export interface BatchRequest {
   lines: string[];
   targetLanguage?: string; // For translations
   sourceLanguage?: string; // For romanizations
   signal?: AbortSignal;
 }
 
-interface BatchTranslationResponse {
+export interface BatchTranslationResponse {
   results: (TranslationResult | null)[];
   detectedLanguage: string;
+  translationSource?: string;
+  translationError?: boolean;
 }
 
 interface BatchRomanizationResponse {
@@ -43,6 +47,39 @@ export async function translateBatch(request: BatchRequest): Promise<BatchTransl
   const { lines, targetLanguage, signal } = request;
   if (!targetLanguage || lines.length === 0) {
     return { results: lines.map(() => null), detectedLanguage: "" };
+  }
+
+  if (typeof chrome !== "undefined" && chrome.i18n && typeof chrome.i18n.detectLanguage === "function") {
+    const sampleText = lines
+      .map(line => line.trim())
+      .filter(line => line.length > 0 && line !== "♪")
+      .slice(0, 10)
+      .join(" ");
+
+    if (sampleText.length > 0) {
+      try {
+        const detection: any = await new Promise(resolve => {
+          chrome.i18n.detectLanguage(sampleText, resolve);
+        });
+
+        if (detection && detection.isReliable && detection.languages && detection.languages.length > 0) {
+          const detectedLang = detection.languages[0].language;
+          if (langCodesMatch(detectedLang, targetLanguage)) {
+            const results = lines.map(line => ({
+              originalLanguage: detectedLang,
+              translatedText: line,
+            }));
+            return { results, detectedLanguage: detectedLang };
+          }
+        }
+      } catch (e) {
+        log(TRANSLATION_ERROR_LOG, "Error detecting language with chrome.i18n.detectLanguage", e);
+      }
+    }
+  }
+
+  if (AppState.translationProvider === "gemini") {
+    return await translateBatchGemini(request);
   }
 
   const results: (TranslationResult | null)[] = new Array(lines.length).fill(null);
@@ -258,6 +295,18 @@ export async function romanizeBatch(request: BatchRequest): Promise<BatchRomaniz
 export function clearCache(): void {
   cache.romanization.clear();
   cache.translation.clear();
+  try {
+    chrome.storage.local.get(null).then(items => {
+      const keysToRemove = Object.keys(items).filter(
+        key => key.startsWith("gemini_")
+      );
+      if (keysToRemove.length > 0) {
+        chrome.storage.local.remove(keysToRemove);
+      }
+    });
+  } catch (e) {
+    log(TRANSLATION_ERROR_LOG, "Error clearing local cache", e);
+  }
 }
 
 export function getTranslationFromCache(text: string, targetLanguage: string): TranslationResult | null {
@@ -267,4 +316,19 @@ export function getTranslationFromCache(text: string, targetLanguage: string): T
 
 export function getRomanizationFromCache(text: string): string | null {
   return cache.romanization.get(text.trim()) || null;
+}
+
+export async function clearTranslationCache(): Promise<void> {
+  cache.translation.clear();
+  try {
+    const items = await chrome.storage.local.get(null);
+    const keysToRemove = Object.keys(items).filter(
+      key => key.startsWith("gemini_")
+    );
+    if (keysToRemove.length > 0) {
+      await chrome.storage.local.remove(keysToRemove);
+    }
+  } catch (e) {
+    log(TRANSLATION_ERROR_LOG, "Error clearing local cache", e);
+  }
 }

--- a/src/modules/lyrics/translation.ts
+++ b/src/modules/lyrics/translation.ts
@@ -74,7 +74,7 @@ export async function translateBatch(request: BatchRequest): Promise<BatchTransl
           }
         }
       } catch (e) {
-        log(TRANSLATION_ERROR_LOG, "Error detecting language with chrome.i18n.detectLanguage", e);
+        logCore(TRANSLATION_ERROR_LOG, "Error detecting language with chrome.i18n.detectLanguage", e);
       }
     }
   }
@@ -307,7 +307,7 @@ export function clearCache(): void {
       }
     });
   } catch (e) {
-    log(TRANSLATION_ERROR_LOG, "Error clearing local cache", e);
+    logCore(TRANSLATION_ERROR_LOG, "Error clearing local cache", e);
   }
 }
 
@@ -329,7 +329,7 @@ export async function clearTranslationCache(): Promise<void> {
       await chrome.storage.local.remove(keysToRemove);
     }
   } catch (e) {
-    log(TRANSLATION_ERROR_LOG, "Error clearing local cache", e);
+    logCore(TRANSLATION_ERROR_LOG, "Error clearing local cache", e);
   }
 }
 

--- a/src/modules/lyrics/translation.ts
+++ b/src/modules/lyrics/translation.ts
@@ -320,19 +320,6 @@ export function getRomanizationFromCache(text: string): string | null {
   return cache.romanization.get(text.trim()) || null;
 }
 
-export async function clearTranslationCache(): Promise<void> {
-  cache.translation.clear();
-  try {
-    const items = await chrome.storage.local.get(null);
-    const keysToRemove = Object.keys(items).filter(key => key.startsWith("gemini_"));
-    if (keysToRemove.length > 0) {
-      await chrome.storage.local.remove(keysToRemove);
-    }
-  } catch (e) {
-    logCore(TRANSLATION_ERROR_LOG, "Error clearing local cache", e);
-  }
-}
-
 export function clearMemoryTranslationCache(): void {
   cache.romanization.clear();
   cache.translation.clear();

--- a/src/modules/lyrics/translation.ts
+++ b/src/modules/lyrics/translation.ts
@@ -1,7 +1,10 @@
 import { TRANSLATE_IN_ROMAJI, TRANSLATE_LYRICS_URL, TRANSLATION_ERROR_LOG } from "@constants";
+import { AppState } from "@core/appState";
 import { logCore } from "@core/logger";
+import { langCodesMatch } from "@utils";
+import { translateBatchGemini } from "./geminiTranslation";
 
-interface TranslationResult {
+export interface TranslationResult {
   originalLanguage: string;
   translatedText: string;
 }
@@ -16,16 +19,18 @@ const cache: TranslationCache = {
   translation: new Map(),
 };
 
-interface BatchRequest {
+export interface BatchRequest {
   lines: string[];
   targetLanguage?: string; // For translations
   sourceLanguage?: string; // For romanizations
   signal?: AbortSignal;
 }
 
-interface BatchTranslationResponse {
+export interface BatchTranslationResponse {
   results: (TranslationResult | null)[];
   detectedLanguage: string;
+  translationSource?: string;
+  translationError?: boolean;
 }
 
 interface BatchRomanizationResponse {
@@ -43,6 +48,39 @@ export async function translateBatch(request: BatchRequest): Promise<BatchTransl
   const { lines, targetLanguage, signal } = request;
   if (!targetLanguage || lines.length === 0) {
     return { results: lines.map(() => null), detectedLanguage: "" };
+  }
+
+  if (typeof chrome !== "undefined" && chrome.i18n && typeof chrome.i18n.detectLanguage === "function") {
+    const sampleText = lines
+      .map(line => line.trim())
+      .filter(line => line.length > 0 && line !== "♪")
+      .slice(0, 10)
+      .join(" ");
+
+    if (sampleText.length > 0) {
+      try {
+        const detection: any = await new Promise(resolve => {
+          chrome.i18n.detectLanguage(sampleText, resolve);
+        });
+
+        if (detection && detection.isReliable && detection.languages && detection.languages.length > 0) {
+          const detectedLang = detection.languages[0].language;
+          if (langCodesMatch(detectedLang, targetLanguage)) {
+            const results = lines.map(line => ({
+              originalLanguage: detectedLang,
+              translatedText: line,
+            }));
+            return { results, detectedLanguage: detectedLang };
+          }
+        }
+      } catch (e) {
+        log(TRANSLATION_ERROR_LOG, "Error detecting language with chrome.i18n.detectLanguage", e);
+      }
+    }
+  }
+
+  if (AppState.translationProvider === "gemini") {
+    return await translateBatchGemini(request);
   }
 
   const results: (TranslationResult | null)[] = new Array(lines.length).fill(null);
@@ -261,6 +299,16 @@ export async function romanizeBatch(request: BatchRequest): Promise<BatchRomaniz
 export function clearCache(): void {
   cache.romanization.clear();
   cache.translation.clear();
+  try {
+    chrome.storage.local.get(null).then(items => {
+      const keysToRemove = Object.keys(items).filter(key => key.startsWith("gemini_"));
+      if (keysToRemove.length > 0) {
+        chrome.storage.local.remove(keysToRemove);
+      }
+    });
+  } catch (e) {
+    log(TRANSLATION_ERROR_LOG, "Error clearing local cache", e);
+  }
 }
 
 export function getTranslationFromCache(text: string, targetLanguage: string): TranslationResult | null {
@@ -270,4 +318,22 @@ export function getTranslationFromCache(text: string, targetLanguage: string): T
 
 export function getRomanizationFromCache(text: string): string | null {
   return cache.romanization.get(text.trim()) || null;
+}
+
+export async function clearTranslationCache(): Promise<void> {
+  cache.translation.clear();
+  try {
+    const items = await chrome.storage.local.get(null);
+    const keysToRemove = Object.keys(items).filter(key => key.startsWith("gemini_"));
+    if (keysToRemove.length > 0) {
+      await chrome.storage.local.remove(keysToRemove);
+    }
+  } catch (e) {
+    log(TRANSLATION_ERROR_LOG, "Error clearing local cache", e);
+  }
+}
+
+export function clearMemoryTranslationCache(): void {
+  cache.romanization.clear();
+  cache.translation.clear();
 }

--- a/src/modules/settings/settings.ts
+++ b/src/modules/settings/settings.ts
@@ -222,6 +222,9 @@ export function listenForPopupMessages(): void {
           log(LOG_PREFIX_CONTENT, "Styles loaded from storage and applied");
         });
       }
+    } else if (request.action === "clearTranslationCache") {
+      clearTranslationCache();
+      sendResponse({ success: true });
     } else if (request.action === "updateSettings") {
       clearTranslationCache();
       setUpLog();
@@ -388,22 +391,35 @@ export function hideDockOnIdleInFullscreen(): void {
  * Loads translation and romanization settings from storage and updates AppState.
  */
 export function loadTranslationSettings(): void {
-  getStorage(
-    {
-      isTranslateEnabled: false,
-      isRomanizationEnabled: false,
-      translationLanguage: "en",
-      romanizationDisabledLanguages: [],
-      translationDisabledLanguages: [],
-    },
-    items => {
-      AppState.isTranslateEnabled = items.isTranslateEnabled;
-      AppState.isRomanizationEnabled = items.isRomanizationEnabled;
-      AppState.translationLanguage = items.translationLanguage || "en";
-      AppState.romanizationDisabledLanguages = items.romanizationDisabledLanguages || [];
-      AppState.translationDisabledLanguages = items.translationDisabledLanguages || [];
-    }
-  );
+  chrome.storage.local.get({ geminiApiKey: "" }, localItems => {
+    getStorage(
+      {
+        isTranslateEnabled: false,
+        translationProvider: "google",
+        geminiModelFallback: ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"],
+        geminiTranslationMode: "speed",
+        isRomanizationEnabled: false,
+        translationLanguage: "en",
+        romanizationDisabledLanguages: [],
+        translationDisabledLanguages: [],
+      },
+      items => {
+        AppState.isTranslateEnabled = items.isTranslateEnabled;
+        AppState.translationProvider = items.translationProvider || "google";
+        AppState.geminiApiKey = (localItems as any).geminiApiKey || "";
+        AppState.geminiModelFallback = items.geminiModelFallback || [
+          "gemini-3.1-flash-lite",
+          "gemini-3.5-flash-lite",
+          "gemini-3.6-flash",
+        ];
+        AppState.geminiTranslationMode = (items.geminiTranslationMode as "speed" | "quality") || "speed";
+        AppState.isRomanizationEnabled = items.isRomanizationEnabled;
+        AppState.translationLanguage = items.translationLanguage || "en";
+        AppState.romanizationDisabledLanguages = items.romanizationDisabledLanguages || [];
+        AppState.translationDisabledLanguages = items.translationDisabledLanguages || [];
+      }
+    );
+  });
 }
 
 /**

--- a/src/modules/settings/settings.ts
+++ b/src/modules/settings/settings.ts
@@ -226,6 +226,9 @@ export function listenForPopupMessages(): void {
           logContent("Styles loaded from storage and applied");
         });
       }
+    } else if (request.action === "clearTranslationCache") {
+      clearTranslationCache();
+      sendResponse({ success: true });
     } else if (request.action === "updateSettings") {
       clearTranslationCache();
       applyLoggingSetting();
@@ -397,22 +400,35 @@ export function hideDockOnIdleInFullscreen(): void {
  * Loads translation and romanization settings from storage and updates AppState.
  */
 export function loadTranslationSettings(): void {
-  getStorage(
-    {
-      isTranslateEnabled: false,
-      isRomanizationEnabled: false,
-      translationLanguage: "en",
-      romanizationDisabledLanguages: [],
-      translationDisabledLanguages: [],
-    },
-    items => {
-      AppState.isTranslateEnabled = items.isTranslateEnabled;
-      AppState.isRomanizationEnabled = items.isRomanizationEnabled;
-      AppState.translationLanguage = items.translationLanguage || "en";
-      AppState.romanizationDisabledLanguages = items.romanizationDisabledLanguages || [];
-      AppState.translationDisabledLanguages = items.translationDisabledLanguages || [];
-    }
-  );
+  chrome.storage.local.get({ geminiApiKey: "" }, localItems => {
+    getStorage(
+      {
+        isTranslateEnabled: false,
+        translationProvider: "google",
+        geminiModelFallback: ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"],
+        geminiTranslationMode: "speed",
+        isRomanizationEnabled: false,
+        translationLanguage: "en",
+        romanizationDisabledLanguages: [],
+        translationDisabledLanguages: [],
+      },
+      items => {
+        AppState.isTranslateEnabled = items.isTranslateEnabled;
+        AppState.translationProvider = items.translationProvider || "google";
+        AppState.geminiApiKey = (localItems as any).geminiApiKey || "";
+        AppState.geminiModelFallback = items.geminiModelFallback || [
+          "gemini-3.1-flash-lite",
+          "gemini-3.5-flash-lite",
+          "gemini-3.6-flash",
+        ];
+        AppState.geminiTranslationMode = (items.geminiTranslationMode as "speed" | "quality") || "speed";
+        AppState.isRomanizationEnabled = items.isRomanizationEnabled;
+        AppState.translationLanguage = items.translationLanguage || "en";
+        AppState.romanizationDisabledLanguages = items.romanizationDisabledLanguages || [];
+        AppState.translationDisabledLanguages = items.translationDisabledLanguages || [];
+      }
+    );
+  });
 }
 
 /**

--- a/src/modules/ui/dom.ts
+++ b/src/modules/ui/dom.ts
@@ -1620,3 +1620,28 @@ export function setExtraHeight() {
 
   document.documentElement.style.setProperty("--blyrics-padding-bottom", Math.ceil(extraHeight) + "px");
 }
+
+export function updateTranslationSource(source: string | null): void {
+  const footerRoot = document.querySelector(".blyrics-footer") || document.querySelector(".blyrics-footer__container");
+  if (!footerRoot) return;
+
+  let capsule = document.getElementById("translation-source-capsule");
+
+  if (!source) {
+    capsule?.remove();
+    return;
+  }
+
+  if (!capsule) {
+    capsule = document.createElement("div");
+    capsule.id = "translation-source-capsule";
+    capsule.className = `${FOOTER_CLASS}__container translation-source-capsule`;
+    footerRoot.appendChild(capsule);
+  }
+
+  if (source === "error") {
+    capsule.textContent = t("lyrics_translationErrorGemini");
+  } else {
+    capsule.textContent = `${t("lyrics_translationSource")}${source}`;
+  }
+}

--- a/src/modules/ui/dom.ts
+++ b/src/modules/ui/dom.ts
@@ -1638,3 +1638,29 @@ function observeFooterForRecalc(footer: HTMLElement): void {
   });
   footerResizeObserver.observe(footer);
 }
+
+export function updateTranslationSource(source: string | null): void {
+  const footerRoot = document.querySelector(".blyrics-footer") || document.querySelector(".blyrics-footer__container");
+  if (!footerRoot) return;
+
+  let capsule = document.getElementById("translation-source-capsule");
+
+  if (!source) {
+    capsule?.remove();
+    return;
+  }
+
+  if (!capsule) {
+    capsule = document.createElement("div");
+    capsule.id = "translation-source-capsule";
+    capsule.className = `${FOOTER_CLASS}__container translation-source-capsule`;
+    footerRoot.appendChild(capsule);
+  }
+
+  if (source === "error") {
+    capsule.textContent = t("lyrics_translationErrorGemini");
+  } else {
+    capsule.textContent = `${t("lyrics_translationSource")}${source}`;
+  }
+}
+

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -211,6 +211,25 @@
 							<span class="checkmark"></span>
 						</label>
 					</div>
+					<div class="container" id="translationProviderContainer" style="display: none;">
+						<span>__MSG_options_language_translationProvider__</span>
+						<div class="select">
+							<select id="translationProvider">
+								<option value="google">__MSG_options_language_googleTranslate__</option>
+								<option value="gemini">__MSG_options_language_geminiApi__</option>
+							</select>
+						</div>
+					</div>
+					<div class="container container--small" id="geminiApiContainer" style="display: none;">
+						<p>__MSG_options_language_geminiApiSettings__</p>
+						<input type="password" id="geminiApiKey" placeholder="__MSG_options_language_geminiApiKeyPlaceholder__" style="margin-bottom: 0.5rem; width: 100%; box-sizing: border-box; background: var(--bg-1); border: 1px solid var(--border); color: var(--fg); padding: 0.4rem; border-radius: 4px;">
+						<button class="small-btn" id="gemini-models-btn">
+							__MSG_options_language_manageModelFallback__
+						</button>
+						<button class="small-btn btn-danger" id="clear-translation-cache-btn" style="margin-top: 0.5rem;">
+							__MSG_options_language_clearTranslationCache__
+						</button>
+					</div>
 					<div class="container">
 						<span>__MSG_options_language_translationLanguage__</span>
 						<div class="select">
@@ -558,6 +577,35 @@
 
 				<div class="modal-footer">
 					<button id="lang-exclusions-reset-btn" class="modal-btn modal-btn-secondary">__MSG_options_resetToDefault__</button>
+				</div>
+			</div>
+		</div>
+
+		<div id="gemini-models-modal-overlay" class="modal-overlay">
+			<div class="modal unison-actions-modal">
+				<div class="modal-header">
+					<h3 class="modal-title">__MSG_options_language_modelFallbackSequence__</h3>
+					<button id="gemini-models-modal-close" class="modal-close-btn" aria-label="Close">
+						<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor">
+							<path d="M6.28 5.22a.75.75 0 0 0-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 1 0 1.06 1.06L10 11.06l3.72 3.72a.75.75 0 1 0 1.06-1.06L11.06 10l3.72-3.72a.75.75 0 0 0-1.06-1.06L10 8.94 6.28 5.22Z"></path>
+						</svg>
+					</button>
+				</div>
+				<div class="modal-body">
+					<p style="margin-bottom:1rem; opacity:0.8; font-size:0.9rem;">__MSG_options_language_dragToReorder__</p>
+					<ul id="geminiModelFallbackList" class="sortable-list" style="padding:0; margin:0; list-style:none;"></ul>
+					<div class="container" style="margin-top:1.5rem;">
+						<span>__MSG_options_language_translationMode__</span>
+						<div class="select">
+							<select id="geminiTranslationMode">
+								<option value="speed">__MSG_options_language_translationModeSpeed__</option>
+								<option value="quality">__MSG_options_language_translationModeQuality__</option>
+							</select>
+						</div>
+					</div>
+				</div>
+				<div class="modal-footer">
+					<button id="gemini-models-reset-btn" class="modal-btn modal-btn-secondary"></button>
 				</div>
 			</div>
 		</div>

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -29,6 +29,10 @@ interface Options {
   pipTextTransition: string;
   pipMarqueeEnabled: boolean;
   isTranslateEnabled: boolean;
+  translationProvider: "google" | "gemini";
+  geminiApiKey: string;
+  geminiModelFallback: string[];
+  geminiTranslationMode?: "speed" | "quality";
   translationLanguage: string;
   isCursorAutoHideEnabled: boolean;
   isRomanizationEnabled: boolean;
@@ -90,6 +94,19 @@ const getOptionsFromForm = (): Options => {
     pipTextTransition: (document.getElementById("pipTextTransition") as HTMLSelectElement).value,
     pipMarqueeEnabled: (document.getElementById("pipMarqueeEnabled") as HTMLInputElement).checked,
     isTranslateEnabled: (document.getElementById("translate") as HTMLInputElement).checked,
+    translationProvider: (document.getElementById("translationProvider") as HTMLSelectElement).value as
+      | "google"
+      | "gemini",
+    geminiApiKey: (document.getElementById("geminiApiKey") as HTMLInputElement).value,
+    geminiModelFallback: Array.from(document.getElementById("geminiModelFallbackList")!.children)
+      .filter(c => {
+        const checkbox = c.querySelector("input[type='checkbox']") as HTMLInputElement | null;
+        return checkbox ? checkbox.checked : true;
+      })
+      .map(c => c.getAttribute("data-model")!),
+    geminiTranslationMode: (document.getElementById("geminiTranslationMode") as HTMLSelectElement).value as
+      | "speed"
+      | "quality",
     translationLanguage: (document.getElementById("translationLanguage") as HTMLInputElement).value,
     isCursorAutoHideEnabled: (document.getElementById("cursorAutoHide") as HTMLInputElement).checked,
     isRomanizationEnabled: (document.getElementById("isRomanizationEnabled") as HTMLInputElement).checked,
@@ -142,12 +159,15 @@ function setDockControlsOrderInForm(order: string[]): void {
 
 // Function to save options to Chrome storage
 const saveOptionsToStorage = (options: Options): void => {
-  chrome.storage.sync.set(options, () => {
-    chrome.tabs.query({ url: "https://music.youtube.com/*" }, tabs => {
-      tabs.forEach(tab => {
-        chrome.tabs.sendMessage(tab.id!, {
-          action: "updateSettings",
-          settings: options,
+  const { geminiApiKey, ...syncOptions } = options;
+  chrome.storage.local.set({ geminiApiKey }, () => {
+    chrome.storage.sync.set(syncOptions, () => {
+      chrome.tabs.query({ url: "https://music.youtube.com/*" }, tabs => {
+        tabs.forEach(tab => {
+          chrome.tabs.sendMessage(tab.id!, {
+            action: "updateSettings",
+            settings: options,
+          });
         });
       });
     });
@@ -276,6 +296,10 @@ const restoreOptions = (): void => {
     pipTextTransition: "spring",
     pipMarqueeEnabled: true,
     isTranslateEnabled: false,
+    translationProvider: "google",
+    geminiApiKey: "",
+    geminiModelFallback: ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"],
+    geminiTranslationMode: "speed",
     translationLanguage: "en",
     isRomanizationEnabled: false,
     preferredProviderList: [
@@ -319,18 +343,23 @@ const restoreOptions = (): void => {
     "isUnisonAutoHideInFullscreenEnabled",
   ];
 
-  chrome.storage.sync.get(readKeys, (raw: { [key: string]: any }) => {
-    setOptionsInForm({
-      ...defaultOptions,
-      ...(raw as Options),
-      isControlsDockEnabled:
-        raw.isControlsDockEnabled ?? raw.isUnisonPinnedDockEnabled ?? defaultOptions.isControlsDockEnabled,
-      controlsDockPosition:
-        raw.controlsDockPosition ?? raw.unisonPinnedDockPosition ?? defaultOptions.controlsDockPosition,
-      isControlsDockAutoHideInFullscreenEnabled:
-        raw.isControlsDockAutoHideInFullscreenEnabled ??
-        raw.isUnisonAutoHideInFullscreenEnabled ??
-        defaultOptions.isControlsDockAutoHideInFullscreenEnabled,
+  const syncKeys = readKeys.filter(k => k !== "geminiApiKey");
+  chrome.storage.local.get("geminiApiKey", (localRaw) => {
+    const geminiApiKey = (localRaw as any).geminiApiKey ?? defaultOptions.geminiApiKey;
+    chrome.storage.sync.get(syncKeys, (raw: { [key: string]: any }) => {
+      setOptionsInForm({
+        ...defaultOptions,
+        ...(raw as Options),
+        geminiApiKey,
+        isControlsDockEnabled:
+          raw.isControlsDockEnabled ?? raw.isUnisonPinnedDockEnabled ?? defaultOptions.isControlsDockEnabled,
+        controlsDockPosition:
+          raw.controlsDockPosition ?? raw.unisonPinnedDockPosition ?? defaultOptions.controlsDockPosition,
+        isControlsDockAutoHideInFullscreenEnabled:
+          raw.isControlsDockAutoHideInFullscreenEnabled ??
+          raw.isUnisonAutoHideInFullscreenEnabled ??
+          defaultOptions.isControlsDockAutoHideInFullscreenEnabled,
+      });
     });
   });
 
@@ -357,6 +386,11 @@ const setOptionsInForm = (items: Options): void => {
   (document.getElementById("pipTextTransition") as HTMLSelectElement).value = items.pipTextTransition;
   (document.getElementById("pipMarqueeEnabled") as HTMLInputElement).checked = items.pipMarqueeEnabled;
   (document.getElementById("translate") as HTMLInputElement).checked = items.isTranslateEnabled;
+  (document.getElementById("translationProvider") as HTMLSelectElement).value = items.translationProvider || "google";
+  (document.getElementById("geminiApiKey") as HTMLInputElement).value = items.geminiApiKey || "";
+  renderGeminiModelsList(items.geminiModelFallback || ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"]);
+  (document.getElementById("geminiTranslationMode") as HTMLSelectElement).value =
+    items.geminiTranslationMode || "speed";
   (document.getElementById("translationLanguage") as HTMLInputElement).value = items.translationLanguage;
   (document.getElementById("isRomanizationEnabled") as HTMLInputElement).checked = items.isRomanizationEnabled;
   (document.getElementById("uiLanguage") as HTMLSelectElement).value = items.uiLanguage;
@@ -558,6 +592,57 @@ function createProviderElem(providerId: string, checked = true): HTMLLIElement |
 
 // -- Display Language Dropdown --------------------------
 
+function renderGeminiModelsList(enabledModels: string[]) {
+  const list = document.getElementById("geminiModelFallbackList");
+  if (!list) return;
+  list.innerHTML = "";
+
+  const ALL_GEMINI_MODELS = ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"];
+  const allModels = [...enabledModels, ...ALL_GEMINI_MODELS.filter(m => !enabledModels.includes(m))];
+
+  allModels.forEach(model => {
+    const isChecked = enabledModels.includes(model);
+    const li = document.createElement("li");
+    li.className = "sortable-item";
+    if (!isChecked) {
+      li.classList.add("disabled-item");
+    }
+    li.setAttribute("data-model", model);
+
+    const handleElem = document.createElement("span");
+    handleElem.classList.add("sortable-handle");
+    li.appendChild(handleElem);
+
+    const labelElem = document.createElement("label");
+    labelElem.classList.add("checkbox-container");
+
+    const checkboxElem = document.createElement("input");
+    checkboxElem.type = "checkbox";
+    checkboxElem.checked = isChecked;
+    checkboxElem.addEventListener("change", () => {
+      if (checkboxElem.checked) {
+        li.classList.remove("disabled-item");
+      } else {
+        li.classList.add("disabled-item");
+      }
+      saveOptions();
+    });
+    labelElem.appendChild(checkboxElem);
+
+    const checkmarkElem = document.createElement("span");
+    checkmarkElem.classList.add("checkmark");
+    labelElem.appendChild(checkmarkElem);
+
+    const textElem = document.createElement("span");
+    textElem.classList.add("provider-name");
+    textElem.textContent = model;
+
+    li.appendChild(labelElem);
+    li.appendChild(textElem);
+    list.appendChild(li);
+  });
+}
+
 function populateLanguageDropdown(): void {
   const select = document.getElementById("uiLanguage") as HTMLSelectElement | undefined;
   if (!select) return;
@@ -605,6 +690,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   initSettingHelpTooltips();
   restoreOptions();
   restoreActiveTab();
+
+  new Sortable(document.getElementById("geminiModelFallbackList")!, {
+    animation: 150,
+    ghostClass: "dragging",
+    forceFallback: true,
+    onUpdate: saveOptions,
+  });
 });
 document.querySelectorAll("#options input, #options select").forEach(element => {
   element.addEventListener("change", saveOptions);
@@ -1235,14 +1327,73 @@ let activeExclusionTab: "romanization" | "translation" = "romanization";
 function updateExclusionsConfigVisibility(): void {
   const romanizationToggle = document.getElementById("isRomanizationEnabled") as HTMLInputElement;
   const translateToggle = document.getElementById("translate") as HTMLInputElement;
+  const translationProvider = document.getElementById("translationProvider") as HTMLSelectElement;
   const configContainer = document.getElementById("romanization-config-container");
-  if (!configContainer) return;
+  const providerContainer = document.getElementById("translationProviderContainer");
+  const geminiContainer = document.getElementById("geminiApiContainer");
 
-  const shouldShow = romanizationToggle?.checked || translateToggle?.checked;
-  configContainer.style.display = shouldShow ? "flex" : "none";
+  if (configContainer) {
+    configContainer.style.display = romanizationToggle?.checked || translateToggle?.checked ? "flex" : "none";
+  }
+  if (providerContainer) {
+    providerContainer.style.display = translateToggle?.checked ? "flex" : "none";
+  }
+  if (geminiContainer) {
+    geminiContainer.style.display =
+      translateToggle?.checked && translationProvider?.value === "gemini" ? "block" : "none";
+  }
 }
 
 function initLangExclusionsModal(): void {
+  const translationProvider = document.getElementById("translationProvider") as HTMLSelectElement;
+  translationProvider?.addEventListener("change", () => {
+    updateExclusionsConfigVisibility();
+    saveOptions();
+  });
+
+  const clearTranslationCacheBtn = document.getElementById("clear-translation-cache-btn");
+  clearTranslationCacheBtn?.addEventListener("click", () => {
+    chrome.tabs.query({ url: "https://music.youtube.com/*" }, tabs => {
+      tabs.forEach(tab => {
+        chrome.tabs.sendMessage(tab.id!, { action: "clearTranslationCache" });
+      });
+    });
+    const status = document.getElementById("status")!;
+    status.innerText = t("options_language_translationCacheCleared");
+    status.classList.add("active");
+    setTimeout(() => {
+      status.classList.remove("active");
+    }, 2000);
+  });
+
+  const geminiModelsBtn = document.getElementById("gemini-models-btn");
+  const geminiModalOverlay = document.getElementById("gemini-models-modal-overlay");
+  const geminiModalClose = document.getElementById("gemini-models-modal-close");
+  const geminiTranslationMode = document.getElementById("geminiTranslationMode") as HTMLSelectElement | null;
+  const resetFallbackBtn = document.getElementById("gemini-models-reset-btn");
+
+  geminiModelsBtn?.addEventListener("click", () => geminiModalOverlay?.classList.add("active"));
+  geminiModalClose?.addEventListener("click", () => geminiModalOverlay?.classList.remove("active"));
+  geminiModalOverlay?.addEventListener("click", e => {
+    if (e.target === geminiModalOverlay) geminiModalOverlay?.classList.remove("active");
+  });
+
+  geminiTranslationMode?.addEventListener("change", () => {
+    saveOptions();
+  });
+
+  if (resetFallbackBtn) {
+    resetFallbackBtn.textContent = t("options_resetToDefault", t("options_language_sequence"));
+    resetFallbackBtn.addEventListener("click", () => {
+      const defaultFallback = ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"];
+      renderGeminiModelsList(defaultFallback);
+      if (geminiTranslationMode) {
+        geminiTranslationMode.value = "speed";
+      }
+      saveOptions();
+    });
+  }
+
   const romanizationToggle = document.getElementById("isRomanizationEnabled") as HTMLInputElement;
   const translateToggle = document.getElementById("translate") as HTMLInputElement;
   const configBtn = document.getElementById("romanization-config-btn");

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -344,7 +344,7 @@ const restoreOptions = (): void => {
   ];
 
   const syncKeys = readKeys.filter(k => k !== "geminiApiKey");
-  chrome.storage.local.get("geminiApiKey", (localRaw) => {
+  chrome.storage.local.get("geminiApiKey", localRaw => {
     const geminiApiKey = (localRaw as any).geminiApiKey ?? defaultOptions.geminiApiKey;
     chrome.storage.sync.get(syncKeys, (raw: { [key: string]: any }) => {
       setOptionsInForm({
@@ -388,7 +388,9 @@ const setOptionsInForm = (items: Options): void => {
   (document.getElementById("translate") as HTMLInputElement).checked = items.isTranslateEnabled;
   (document.getElementById("translationProvider") as HTMLSelectElement).value = items.translationProvider || "google";
   (document.getElementById("geminiApiKey") as HTMLInputElement).value = items.geminiApiKey || "";
-  renderGeminiModelsList(items.geminiModelFallback || ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"]);
+  renderGeminiModelsList(
+    items.geminiModelFallback || ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"]
+  );
   (document.getElementById("geminiTranslationMode") as HTMLSelectElement).value =
     items.geminiTranslationMode || "speed";
   (document.getElementById("translationLanguage") as HTMLInputElement).value = items.translationLanguage;

--- a/src/options/options.ts
+++ b/src/options/options.ts
@@ -30,6 +30,10 @@ interface Options {
   pipTextTransition: string;
   pipMarqueeEnabled: boolean;
   isTranslateEnabled: boolean;
+  translationProvider: "google" | "gemini";
+  geminiApiKey: string;
+  geminiModelFallback: string[];
+  geminiTranslationMode?: "speed" | "quality";
   translationLanguage: string;
   isCursorAutoHideEnabled: boolean;
   isRomanizationEnabled: boolean;
@@ -93,6 +97,19 @@ const getOptionsFromForm = (): Options => {
     pipTextTransition: (document.getElementById("pipTextTransition") as HTMLSelectElement).value,
     pipMarqueeEnabled: (document.getElementById("pipMarqueeEnabled") as HTMLInputElement).checked,
     isTranslateEnabled: (document.getElementById("translate") as HTMLInputElement).checked,
+    translationProvider: (document.getElementById("translationProvider") as HTMLSelectElement).value as
+      | "google"
+      | "gemini",
+    geminiApiKey: (document.getElementById("geminiApiKey") as HTMLInputElement).value,
+    geminiModelFallback: Array.from(document.getElementById("geminiModelFallbackList")!.children)
+      .filter(c => {
+        const checkbox = c.querySelector("input[type='checkbox']") as HTMLInputElement | null;
+        return checkbox ? checkbox.checked : true;
+      })
+      .map(c => c.getAttribute("data-model")!),
+    geminiTranslationMode: (document.getElementById("geminiTranslationMode") as HTMLSelectElement).value as
+      | "speed"
+      | "quality",
     translationLanguage: (document.getElementById("translationLanguage") as HTMLInputElement).value,
     isCursorAutoHideEnabled: (document.getElementById("cursorAutoHide") as HTMLInputElement).checked,
     isRomanizationEnabled: (document.getElementById("isRomanizationEnabled") as HTMLInputElement).checked,
@@ -146,12 +163,15 @@ function setDockControlsOrderInForm(order: string[]): void {
 
 // Function to save options to Chrome storage
 const saveOptionsToStorage = (options: Options): void => {
-  chrome.storage.sync.set(options, () => {
-    chrome.tabs.query({ url: "https://music.youtube.com/*" }, tabs => {
-      tabs.forEach(tab => {
-        chrome.tabs.sendMessage(tab.id!, {
-          action: "updateSettings",
-          settings: options,
+  const { geminiApiKey, ...syncOptions } = options;
+  chrome.storage.local.set({ geminiApiKey }, () => {
+    chrome.storage.sync.set(syncOptions, () => {
+      chrome.tabs.query({ url: "https://music.youtube.com/*" }, tabs => {
+        tabs.forEach(tab => {
+          chrome.tabs.sendMessage(tab.id!, {
+            action: "updateSettings",
+            settings: options,
+          });
         });
       });
     });
@@ -281,6 +301,10 @@ const restoreOptions = (): void => {
     pipTextTransition: "spring",
     pipMarqueeEnabled: true,
     isTranslateEnabled: false,
+    translationProvider: "google",
+    geminiApiKey: "",
+    geminiModelFallback: ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"],
+    geminiTranslationMode: "speed",
     translationLanguage: "en",
     isRomanizationEnabled: false,
     preferredProviderList: [
@@ -325,18 +349,23 @@ const restoreOptions = (): void => {
     "isUnisonAutoHideInFullscreenEnabled",
   ];
 
-  chrome.storage.sync.get(readKeys, (raw: { [key: string]: any }) => {
-    setOptionsInForm({
-      ...defaultOptions,
-      ...(raw as Options),
-      isControlsDockEnabled:
-        raw.isControlsDockEnabled ?? raw.isUnisonPinnedDockEnabled ?? defaultOptions.isControlsDockEnabled,
-      controlsDockPosition:
-        raw.controlsDockPosition ?? raw.unisonPinnedDockPosition ?? defaultOptions.controlsDockPosition,
-      isControlsDockAutoHideInFullscreenEnabled:
-        raw.isControlsDockAutoHideInFullscreenEnabled ??
-        raw.isUnisonAutoHideInFullscreenEnabled ??
-        defaultOptions.isControlsDockAutoHideInFullscreenEnabled,
+  const syncKeys = readKeys.filter(k => k !== "geminiApiKey");
+  chrome.storage.local.get("geminiApiKey", localRaw => {
+    const geminiApiKey = (localRaw as any).geminiApiKey ?? defaultOptions.geminiApiKey;
+    chrome.storage.sync.get(syncKeys, (raw: { [key: string]: any }) => {
+      setOptionsInForm({
+        ...defaultOptions,
+        ...(raw as Options),
+        geminiApiKey,
+        isControlsDockEnabled:
+          raw.isControlsDockEnabled ?? raw.isUnisonPinnedDockEnabled ?? defaultOptions.isControlsDockEnabled,
+        controlsDockPosition:
+          raw.controlsDockPosition ?? raw.unisonPinnedDockPosition ?? defaultOptions.controlsDockPosition,
+        isControlsDockAutoHideInFullscreenEnabled:
+          raw.isControlsDockAutoHideInFullscreenEnabled ??
+          raw.isUnisonAutoHideInFullscreenEnabled ??
+          defaultOptions.isControlsDockAutoHideInFullscreenEnabled,
+      });
     });
   });
 
@@ -364,6 +393,13 @@ const setOptionsInForm = (items: Options): void => {
   (document.getElementById("pipTextTransition") as HTMLSelectElement).value = items.pipTextTransition;
   (document.getElementById("pipMarqueeEnabled") as HTMLInputElement).checked = items.pipMarqueeEnabled;
   (document.getElementById("translate") as HTMLInputElement).checked = items.isTranslateEnabled;
+  (document.getElementById("translationProvider") as HTMLSelectElement).value = items.translationProvider || "google";
+  (document.getElementById("geminiApiKey") as HTMLInputElement).value = items.geminiApiKey || "";
+  renderGeminiModelsList(
+    items.geminiModelFallback || ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"]
+  );
+  (document.getElementById("geminiTranslationMode") as HTMLSelectElement).value =
+    items.geminiTranslationMode || "speed";
   (document.getElementById("translationLanguage") as HTMLInputElement).value = items.translationLanguage;
   (document.getElementById("isRomanizationEnabled") as HTMLInputElement).checked = items.isRomanizationEnabled;
   (document.getElementById("uiLanguage") as HTMLSelectElement).value = items.uiLanguage;
@@ -567,6 +603,57 @@ function createProviderElem(providerId: string, checked = true): HTMLLIElement |
 
 // -- Display Language Dropdown --------------------------
 
+function renderGeminiModelsList(enabledModels: string[]) {
+  const list = document.getElementById("geminiModelFallbackList");
+  if (!list) return;
+  list.innerHTML = "";
+
+  const ALL_GEMINI_MODELS = ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"];
+  const allModels = [...enabledModels, ...ALL_GEMINI_MODELS.filter(m => !enabledModels.includes(m))];
+
+  allModels.forEach(model => {
+    const isChecked = enabledModels.includes(model);
+    const li = document.createElement("li");
+    li.className = "sortable-item";
+    if (!isChecked) {
+      li.classList.add("disabled-item");
+    }
+    li.setAttribute("data-model", model);
+
+    const handleElem = document.createElement("span");
+    handleElem.classList.add("sortable-handle");
+    li.appendChild(handleElem);
+
+    const labelElem = document.createElement("label");
+    labelElem.classList.add("checkbox-container");
+
+    const checkboxElem = document.createElement("input");
+    checkboxElem.type = "checkbox";
+    checkboxElem.checked = isChecked;
+    checkboxElem.addEventListener("change", () => {
+      if (checkboxElem.checked) {
+        li.classList.remove("disabled-item");
+      } else {
+        li.classList.add("disabled-item");
+      }
+      saveOptions();
+    });
+    labelElem.appendChild(checkboxElem);
+
+    const checkmarkElem = document.createElement("span");
+    checkmarkElem.classList.add("checkmark");
+    labelElem.appendChild(checkmarkElem);
+
+    const textElem = document.createElement("span");
+    textElem.classList.add("provider-name");
+    textElem.textContent = model;
+
+    li.appendChild(labelElem);
+    li.appendChild(textElem);
+    list.appendChild(li);
+  });
+}
+
 function populateLanguageDropdown(): void {
   const select = document.getElementById("uiLanguage") as HTMLSelectElement | undefined;
   if (!select) return;
@@ -614,6 +701,13 @@ document.addEventListener("DOMContentLoaded", async () => {
   initSettingHelpTooltips();
   restoreOptions();
   restoreActiveTab();
+
+  new Sortable(document.getElementById("geminiModelFallbackList")!, {
+    animation: 150,
+    ghostClass: "dragging",
+    forceFallback: true,
+    onUpdate: saveOptions,
+  });
 });
 document.querySelectorAll("#options input, #options select").forEach(element => {
   element.addEventListener("change", saveOptions);
@@ -1244,14 +1338,73 @@ let activeExclusionTab: "romanization" | "translation" = "romanization";
 function updateExclusionsConfigVisibility(): void {
   const romanizationToggle = document.getElementById("isRomanizationEnabled") as HTMLInputElement;
   const translateToggle = document.getElementById("translate") as HTMLInputElement;
+  const translationProvider = document.getElementById("translationProvider") as HTMLSelectElement;
   const configContainer = document.getElementById("romanization-config-container");
-  if (!configContainer) return;
+  const providerContainer = document.getElementById("translationProviderContainer");
+  const geminiContainer = document.getElementById("geminiApiContainer");
 
-  const shouldShow = romanizationToggle?.checked || translateToggle?.checked;
-  configContainer.style.display = shouldShow ? "flex" : "none";
+  if (configContainer) {
+    configContainer.style.display = romanizationToggle?.checked || translateToggle?.checked ? "flex" : "none";
+  }
+  if (providerContainer) {
+    providerContainer.style.display = translateToggle?.checked ? "flex" : "none";
+  }
+  if (geminiContainer) {
+    geminiContainer.style.display =
+      translateToggle?.checked && translationProvider?.value === "gemini" ? "block" : "none";
+  }
 }
 
 function initLangExclusionsModal(): void {
+  const translationProvider = document.getElementById("translationProvider") as HTMLSelectElement;
+  translationProvider?.addEventListener("change", () => {
+    updateExclusionsConfigVisibility();
+    saveOptions();
+  });
+
+  const clearTranslationCacheBtn = document.getElementById("clear-translation-cache-btn");
+  clearTranslationCacheBtn?.addEventListener("click", () => {
+    chrome.tabs.query({ url: "https://music.youtube.com/*" }, tabs => {
+      tabs.forEach(tab => {
+        chrome.tabs.sendMessage(tab.id!, { action: "clearTranslationCache" });
+      });
+    });
+    const status = document.getElementById("status")!;
+    status.innerText = t("options_language_translationCacheCleared");
+    status.classList.add("active");
+    setTimeout(() => {
+      status.classList.remove("active");
+    }, 2000);
+  });
+
+  const geminiModelsBtn = document.getElementById("gemini-models-btn");
+  const geminiModalOverlay = document.getElementById("gemini-models-modal-overlay");
+  const geminiModalClose = document.getElementById("gemini-models-modal-close");
+  const geminiTranslationMode = document.getElementById("geminiTranslationMode") as HTMLSelectElement | null;
+  const resetFallbackBtn = document.getElementById("gemini-models-reset-btn");
+
+  geminiModelsBtn?.addEventListener("click", () => geminiModalOverlay?.classList.add("active"));
+  geminiModalClose?.addEventListener("click", () => geminiModalOverlay?.classList.remove("active"));
+  geminiModalOverlay?.addEventListener("click", e => {
+    if (e.target === geminiModalOverlay) geminiModalOverlay?.classList.remove("active");
+  });
+
+  geminiTranslationMode?.addEventListener("change", () => {
+    saveOptions();
+  });
+
+  if (resetFallbackBtn) {
+    resetFallbackBtn.textContent = t("options_resetToDefault", t("options_language_sequence"));
+    resetFallbackBtn.addEventListener("click", () => {
+      const defaultFallback = ["gemini-3.1-flash-lite", "gemini-3.5-flash-lite", "gemini-3.6-flash"];
+      renderGeminiModelsList(defaultFallback);
+      if (geminiTranslationMode) {
+        geminiTranslationMode.value = "speed";
+      }
+      saveOptions();
+    });
+  }
+
   const romanizationToggle = document.getElementById("isRomanizationEnabled") as HTMLInputElement;
   const translateToggle = document.getElementById("translate") as HTMLInputElement;
   const configBtn = document.getElementById("romanization-config-btn");


### PR DESCRIPTION
This is a fresh rewrite of the Gemini translation feature, built cleanly off the latest `master` to address previous review feedback. 

It implements AI translation support using Gemini models with fallback sequence settings, while ensuring no regression of existing master features.

### Key Improvements & Fixes Addressing Feedback
1. **No Regressions**: Rebuilt cleanly from master. Checked out all previous unrelated modifications to locale strings, settings UI, and package lock files.
2. **Transient Storage Cache**: Replaced direct writes to `chrome.storage.local` with `getTransientStorage` / `setTransientStorage`, allowing cached translations to expire cleanly according to `LYRICS_CACHE_TTL_MS` (7 days).
3. **Provider-Aware Cache Keys**: Added the active lyric provider name into the cache key structure (`gemini_${lyricSource}_${model}_...`) to prevent serving old/mismatched translations when changing lyrics providers.
4. **Secure Key Storage**: Switched `geminiApiKey` storage from `chrome.storage.sync` to `chrome.storage.local` to prevent duplicating sensitive billable API credentials across the user's synced devices.
5. **No Package Lock Churn**: Kept `package-lock.json` untouched.

### Verification Plan
- Verified that the extension builds successfully (`npm run build`) and typechecks (`npm run typecheck`) without any warning or error.
- Verified that translation provider switching, API key loading/saving to local storage, and fallback modal drag-to-reorder list work as expected.
