### PR TITLE
chore(deps): bump @braccato/core to 1.2.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.4.0.2",
             "license": "GPL-3.0",
             "dependencies": {
-                "@braccato/core": "1.1.0",
+                "@braccato/core": "1.2.0",
                 "@braccato/parsers": "0.2.0",
                 "@codemirror/autocomplete": "^6.20.3",
                 "@codemirror/commands": "^6.10.4",
@@ -641,9 +641,9 @@
             }
         },
         "node_modules/@braccato/core": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/@braccato/core/-/core-1.1.0.tgz",
-            "integrity": "sha512-BBpwxZq6268HeImaJElD9dBSUcqZCgSon2tF0HlVNSCoqnIqr+FwNrkb99r20rZYCk+z6crOS4zmUw6xyxTHUg==",
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@braccato/core/-/core-1.2.0.tgz",
+            "integrity": "sha512-8sCAaOZT3wbptQKaOZR/JgYhFpGb0sv0CmoYpIkWACXQue1D/oDwJOuJU537qtqmXtG1waJhZzFi6TkB9T6iMg==",
             "license": "MIT",
             "dependencies": {
                 "@braccato/types": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     },
     "homepage": "https://github.com/better-lyrics/better-lyrics#readme",
     "dependencies": {
-        "@braccato/core": "1.1.0",
+        "@braccato/core": "1.2.0",
         "@braccato/parsers": "0.2.0",
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.10.4",


### PR DESCRIPTION
Bumped `@braccato/core` to 1.2.0. Themes can reshape the instrumental ripple through `--blyrics-instrumental-wave-path-high` and `-low` now, so changing that shape no longer means forking the renderer. Comes with a scroll padding fix too: end-of-song padding resizes when a theme moves the scroll target.
