### PR TITLE
chore: bump @braccato/core to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "2.4.0.2",
             "license": "GPL-3.0",
             "dependencies": {
-                "@braccato/core": "1.2.1",
+                "@braccato/core": "1.3.0",
                 "@braccato/parsers": "0.2.0",
                 "@codemirror/autocomplete": "^6.20.3",
                 "@codemirror/commands": "^6.11.0",
@@ -325,9 +325,9 @@
             }
         },
         "node_modules/@braccato/core": {
-            "version": "1.2.1",
-            "resolved": "https://registry.npmjs.org/@braccato/core/-/core-1.2.1.tgz",
-            "integrity": "sha512-44VN3P7mJWXk0zeHPwj0sUZFIm/fNBHnTqJdpNIacmM6LS0EnuPxmIF9iX4TiJM38tlhTq6cTi8GfF2h633XcQ==",
+            "version": "1.3.0",
+            "resolved": "https://registry.npmjs.org/@braccato/core/-/core-1.3.0.tgz",
+            "integrity": "sha512-86OqpXxnRl2itmAyleC6gHi9v3nRN8lD1oxKtTFrAXhYrM2c4DCScJvSNboYdizR7/hPmOiiUiG+uPJJwEhIFg==",
             "license": "MIT",
             "dependencies": {
                 "@braccato/types": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
         "node": ">=22.12"
     },
     "dependencies": {
-        "@braccato/core": "1.2.1",
+        "@braccato/core": "1.3.0",
         "@braccato/parsers": "0.2.0",
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.11.0",


### PR DESCRIPTION
Picks up @braccato/core 1.3.0, which makes highlight targets required in part data. Typecheck passes clean against it.