### PR TITLE
Fix sourcemap uploads with direct R2 S3 writes

### DIFF
--- a/.github/workflows/Build.yml
+++ b/.github/workflows/Build.yml
@@ -7,7 +7,7 @@ on:
   pull_request:
 
 env:
-  HAS_CF_SECRETS: ${{ secrets.CF_ACCOUNT_ID != '' && secrets.CF_ZONE_ID != '' && secrets.CF_API_TOKEN != '' && secrets.SOURCEMAPS_API_KEY != '' && vars.SOURCEMAPS_API_URL != '' }}
+  HAS_R2_SECRETS: ${{ secrets.R2_SOURCEMAPS_ACCESS_KEY_ID != '' && secrets.R2_SOURCEMAPS_SECRET_ACCESS_KEY != '' && vars.R2_SOURCEMAPS_ENDPOINT != '' && vars.R2_SOURCEMAPS_BUCKET != '' && vars.SOURCEMAPS_API_URL != '' }}
   
 jobs:
   build:
@@ -17,14 +17,6 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-
-      - name: Bypass Cloudflare for GitHub Action
-        uses: xiaotianxt/bypass-cloudflare-for-github-action@v2.0.1
-        if: ${{ env.HAS_CF_SECRETS == 'true' }}
-        with:
-          cf_account_id: ${{ secrets.CF_ACCOUNT_ID }}
-          cf_zone_id: ${{ secrets.CF_ZONE_ID }}
-          cf_api_token: ${{ secrets.CF_API_TOKEN }}
 
       - name: Use Node.js
         uses: actions/setup-node@v3
@@ -53,15 +45,18 @@ jobs:
       - name: Update version in files
         run: npm run update-version -- "${{ env.NIGHTLY_VERSION }}"
 
-      - name: Build extension (with sourcemap uplaod)
-        if: ${{ env.HAS_CF_SECRETS == 'true' }}
+      - name: Build extension (with sourcemap upload)
+        if: ${{ env.HAS_R2_SECRETS == 'true' }}
         env:
-          SOURCEMAPS_API_KEY: ${{ secrets.SOURCEMAPS_API_KEY }}
           SOURCEMAPS_BASE_URL: ${{ vars.SOURCEMAPS_API_URL }}
+          R2_ENDPOINT: ${{ vars.R2_SOURCEMAPS_ENDPOINT }}
+          R2_BUCKET: ${{ vars.R2_SOURCEMAPS_BUCKET }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_SOURCEMAPS_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SOURCEMAPS_SECRET_ACCESS_KEY }}
         run: npm run build:ci
 
-      - name: Build extension (without sourcemap uplaod)
-        if: ${{ env.HAS_CF_SECRETS == 'false' }}
+      - name: Build extension (without sourcemap upload)
+        if: ${{ env.HAS_R2_SECRETS == 'false' }}
         run: npm run build
 
       - name: Upload Chrome artifact

--- a/.github/workflows/publish-platform.yml
+++ b/.github/workflows/publish-platform.yml
@@ -78,8 +78,11 @@ jobs:
         if: steps.download.outcome != 'success'
         env:
           RELEASE_TYPE: ${{ steps.meta.outputs.release_type }}
-          SOURCEMAPS_API_KEY: ${{ secrets.SOURCEMAPS_API_KEY }}
           SOURCEMAPS_BASE_URL: ${{ vars.SOURCEMAPS_API_URL }}
+          R2_ENDPOINT: ${{ vars.R2_SOURCEMAPS_ENDPOINT }}
+          R2_BUCKET: ${{ vars.R2_SOURCEMAPS_BUCKET }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_SOURCEMAPS_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SOURCEMAPS_SECRET_ACCESS_KEY }}
         run: |
           echo "Rebuilding from tag v${{ inputs.version }} (no artifact available)."
           rm -rf "dist/${{ inputs.platform }}"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,13 +48,6 @@ jobs:
           app-id: ${{ secrets.APP_ID }}
           private-key: ${{ secrets.APP_PRIVATE_KEY }}
 
-      - name: Bypass Cloudflare for GitHub Action
-        uses: xiaotianxt/bypass-cloudflare-for-github-action@v2.0.1
-        with:
-          cf_account_id: ${{ secrets.CF_ACCOUNT_ID }}
-          cf_zone_id: ${{ secrets.CF_ZONE_ID }}
-          cf_api_token: ${{ secrets.CF_API_TOKEN }}
-
       - name: Checkout code
         uses: actions/checkout@v4
         with:
@@ -80,8 +73,11 @@ jobs:
       - name: Build extension
         env:
           RELEASE_TYPE: ${{ github.event.inputs.is_canary == 'true' && 'canary' || '' }}
-          SOURCEMAPS_API_KEY: ${{ secrets.SOURCEMAPS_API_KEY }}
           SOURCEMAPS_BASE_URL: ${{ vars.SOURCEMAPS_API_URL }}
+          R2_ENDPOINT: ${{ vars.R2_SOURCEMAPS_ENDPOINT }}
+          R2_BUCKET: ${{ vars.R2_SOURCEMAPS_BUCKET }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_SOURCEMAPS_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SOURCEMAPS_SECRET_ACCESS_KEY }}
         run: npm run build:ci
 
       # https://github.com/planetscale/ghcommit-action/issues/43#issuecomment-2313129696

--- a/extension.config.js
+++ b/extension.config.js
@@ -119,6 +119,7 @@ const config = {
   config: rspackConfig => {
     const isCanaryRelease = process.env.RELEASE_TYPE === "canary";
     const isDevelopment = rspackConfig.mode !== "production";
+    const shouldBuildSourcemaps = isDevelopment || process.env.SOURCEMAPS_ENABLED === "true";
 
     rspackConfig.plugins.push(emitRendererStyles);
 
@@ -146,7 +147,7 @@ const config = {
       });
     }
 
-    rspackConfig.devtool = isDevelopment || isCanaryRelease ? "source-map" : false;
+    rspackConfig.devtool = shouldBuildSourcemaps ? "source-map" : false;
     return rspackConfig;
   },
 };

--- a/knip.json
+++ b/knip.json
@@ -12,9 +12,10 @@
     "public/earlyInject.js",
     "public/script.js",
     "src/core/generated/locales.ts",
-    "src/**/*.selfcheck.ts"
+    "src/**/*.selfcheck.ts",
+    "tooling/**/*.ts"
   ],
-  "project": ["src/**/*.ts", "public/**/*.js"],
+  "project": ["src/**/*.ts", "public/**/*.js", "tooling/**/*.ts"],
   "ignoreDependencies": [
     "@codemirror/language",
     "@typescript/lib-dom"

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
                 "sortablejs": "^1.15.7"
             },
             "devDependencies": {
+                "@aws-sdk/client-s3": "^3.1121.0",
                 "@biomejs/biome": "2.0.4",
                 "@types/chrome": "^0.2.7",
                 "@types/jsdom": "^28.0.3",
@@ -95,6 +96,332 @@
             "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
             "dev": true,
             "license": "MIT"
+        },
+        "node_modules/@aws-sdk/checksums": {
+            "version": "3.1000.29",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/checksums/-/checksums-3.1000.29.tgz",
+            "integrity": "sha512-Dtu0gr4dnATZAPwEYbpCsG+MpLM7OAliy2gTepEFQwl1vZ6DL3QMH2FveMa3HLvPsOdhJsPRB3KtxVhph9T75A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/client-s3": {
+            "version": "3.1121.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1121.0.tgz",
+            "integrity": "sha512-hBnoqaVBeWdkgXcJElMXA2yUZWkBCBntu2qmN+tfqmzC+j4LzJC3ox8qIgS2WdMS1cb8UwyBogUVrkRXybNm0A==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/checksums": "^3.1000.29",
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/credential-provider-node": "^3.972.81",
+                "@aws-sdk/middleware-sdk-s3": "^3.972.75",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/fetch-http-handler": "^5.7.2",
+                "@smithy/node-http-handler": "^4.11.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/core": {
+            "version": "3.977.9",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.977.9.tgz",
+            "integrity": "sha512-reqPFEQrZxDZpeGj4PFMepBeR5LGYHRqq/L0motTzgFkCRBA4rFdaVXDSLYyGHhxVz7sT2PDnPN9CluGSfgyJA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.974.5",
+                "@aws-sdk/xml-builder": "^3.972.40",
+                "@aws/lambda-invoke-store": "^0.3.0",
+                "@smithy/core": "^3.33.3",
+                "@smithy/signature-v4": "^5.6.12",
+                "@smithy/types": "^4.17.2",
+                "bowser": "^2.11.0",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-env": {
+            "version": "3.972.70",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.70.tgz",
+            "integrity": "sha512-H404B7dJl2mCrBqahDEYsanB0xhdDp6tXnXcTUnXmmpy2Q3J0Ho0bUajZ2jr/RdwzCyS59Gi8xXIFwPLGBl6Uw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-http": {
+            "version": "3.972.72",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.72.tgz",
+            "integrity": "sha512-X98zYOrVOeuosCX+6ktf29FC2N2GHPLia7qv6mzPzTc+RPAuHWCDS++Z6JK7eGYqb/v6uaW7bAXaOvDBfol+0w==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/fetch-http-handler": "^5.7.2",
+                "@smithy/node-http-handler": "^4.11.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-ini": {
+            "version": "3.973.15",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.973.15.tgz",
+            "integrity": "sha512-Rykg6s5ceBuynMOGWgoowO4N+27JfnqXAnVaSunZl0hOO1XodSrxGNz6sCEbnmS0lAfQZDKyb3fbr46gSuv6Sg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/credential-provider-env": "^3.972.70",
+                "@aws-sdk/credential-provider-http": "^3.972.72",
+                "@aws-sdk/credential-provider-login": "^3.972.77",
+                "@aws-sdk/credential-provider-process": "^3.972.70",
+                "@aws-sdk/credential-provider-sso": "^3.973.14",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+                "@aws-sdk/nested-clients": "^3.997.44",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/credential-provider-imds": "^4.4.16",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-login": {
+            "version": "3.972.77",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.77.tgz",
+            "integrity": "sha512-Jb59xfEISoN5mmbnA+HYqdtrSX3CgCtJoof+V5D8/TgUI56W63GEEd5Y58WijU3Ou6+WEgaLD1feVzaRXV5IDQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/nested-clients": "^3.997.44",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-node": {
+            "version": "3.972.81",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.81.tgz",
+            "integrity": "sha512-Rml+WitoFvXmv6JZ18U/xGdGDGGvB/mOin0ya0lTnTrdC0Z1lrVxTYh7iNklZBcvcRMrs4DoEf6xy1KWyrLQQw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/credential-provider-env": "^3.972.70",
+                "@aws-sdk/credential-provider-http": "^3.972.72",
+                "@aws-sdk/credential-provider-ini": "^3.973.15",
+                "@aws-sdk/credential-provider-process": "^3.972.70",
+                "@aws-sdk/credential-provider-sso": "^3.973.14",
+                "@aws-sdk/credential-provider-web-identity": "^3.972.76",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/credential-provider-imds": "^4.4.16",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-process": {
+            "version": "3.972.70",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.70.tgz",
+            "integrity": "sha512-2ry03fGRJr4sV3jI+ocjj5JqALnFD6ymM5KiNCDZMvq8bX2GSbE0vji4aM43TVCl2nXqqLRZaUxdq/KeWRAY4Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-sso": {
+            "version": "3.973.14",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.973.14.tgz",
+            "integrity": "sha512-jkhg/8ocAAoc0RFyLMhCw+/zZh7gystQgd4F4hznNa8P4Cc501PQmxd+jGLiMHodPJ+7Zv/3znM62gZojyasmA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/nested-clients": "^3.997.44",
+                "@aws-sdk/token-providers": "3.1116.0",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/credential-provider-web-identity": {
+            "version": "3.972.76",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.76.tgz",
+            "integrity": "sha512-d3AGyVu759PGr35mEB2s22xxlNEA5rpdxtSPJthfPFJvoQ8dt357iVPECqWfUxXp1toJAvKmbtcIYVGigaGsCA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/nested-clients": "^3.997.44",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/middleware-sdk-s3": {
+            "version": "3.972.75",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.75.tgz",
+            "integrity": "sha512-wMIsNumRVKaNMKhvU/s9VrdEwE8S6gSzXp4RygFG5BEMnGkkXf8cjh8zf7cKJBpUDpqTWqwbz5isEgp9rH6Lng==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/nested-clients": {
+            "version": "3.997.44",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.44.tgz",
+            "integrity": "sha512-NhEgryjlBF9w38ZXqGymQV28IhkYa1mKhlbYnqIis57AYwWGVYfUPgg/qC2rLRqOUfblxx++irvju10kVTa8Vw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/signature-v4-multi-region": "^3.996.46",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/fetch-http-handler": "^5.7.2",
+                "@smithy/node-http-handler": "^4.11.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/signature-v4-multi-region": {
+            "version": "3.996.46",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.46.tgz",
+            "integrity": "sha512-L+2xZTye/2T96f3lwCws0Zw6GG2JHZW9e8FpVgGBeeExSKyeoZ6CWRpBml/7DNiK/O26jrgPM9F+Ay8VkgzUWQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/signature-v4": "^5.6.12",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/token-providers": {
+            "version": "3.1116.0",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1116.0.tgz",
+            "integrity": "sha512-ygIivKqh8aHzNkucOCXHyIBgBpLPfrSI0mCqXF+vLBsPTUKqj0VSqAY0GFPe7lQl4HntjOcQ+KSyS7oUV2C54Q==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@aws-sdk/core": "^3.977.9",
+                "@aws-sdk/nested-clients": "^3.997.44",
+                "@aws-sdk/types": "^3.974.5",
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/types": {
+            "version": "3.974.5",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.974.5.tgz",
+            "integrity": "sha512-LkwLL2BLbC6wNNm4JaH9mbEqBMdOZCct6VAYqhdN4U1xrWM+fUJQEfbHwQgDypapOWTRtlk25akb5afM0P8CIQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws-sdk/xml-builder": {
+            "version": "3.972.40",
+            "resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.40.tgz",
+            "integrity": "sha512-wlFmCIGUlwF4zx/kncw+bmxTQh1HeSJq4mYV/V5cZUSJadDP3kXvGW8Rn21cimj/7y9ju+47oYWXi97vF7czaA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=20.0.0"
+            }
+        },
+        "node_modules/@aws/lambda-invoke-store": {
+            "version": "0.3.0",
+            "resolved": "https://registry.npmjs.org/@aws/lambda-invoke-store/-/lambda-invoke-store-0.3.0.tgz",
+            "integrity": "sha512-sl4Bm6yiMNYrZKkqqDFWN0UfnWhlS8ivKxrYl+6t0gCLrqr8y3B2IqZZbFRkfaVVp7C/baApyh71P+LeE1A2sQ==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18.0.0"
+            }
         },
         "node_modules/@babel/code-frame": {
             "version": "7.29.7",
@@ -3148,6 +3475,93 @@
                 "url": "https://github.com/sindresorhus/is?sponsor=1"
             }
         },
+        "node_modules/@smithy/core": {
+            "version": "3.33.3",
+            "resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.33.3.tgz",
+            "integrity": "sha512-CsOeKq/9kA3y6VJHt+/+VTCtBaxJ4OTFpgrjIUhPpDIKxBci1k2bJaQASF2h/ELWrulGp+t97DZ0mevfAD8idg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/credential-provider-imds": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.5.2.tgz",
+            "integrity": "sha512-A9uSdn72ozbRUSit0eib0TW7nXuNPlaeM0zcGkJ+nE6tFcSDbnmtwoxbTCFBukVQcszDAyvsd7+rTduPTXpygg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.33.2",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/fetch-http-handler": {
+            "version": "5.7.2",
+            "resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.7.2.tgz",
+            "integrity": "sha512-nZyWTmSpJEXl6VtWVMBJve/7x12DZu6sIX1z1a+ZMaHlQQRs9Zpu6NbTe/gmxYXVRpkjxyDYpZ5gx2IM6f/Wkw==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.33.2",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/node-http-handler": {
+            "version": "4.11.3",
+            "resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.11.3.tgz",
+            "integrity": "sha512-2jY1tSpERfPfWqyBV2pH+iGFaghVsIJszJNsT7hxtQYhVJpWDyc0LqOWI+nXOxOAHaEfZ4PXXtp1wW1TGpHhkA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/signature-v4": {
+            "version": "5.7.3",
+            "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.7.3.tgz",
+            "integrity": "sha512-7ImGm+FkHRLcBaRttIAMZ6bzJZWb2cJGoYjq46F2UjycujWzrL9GEN9h4w7eQyXJYnltrUhxbbieBAIRrdqpow==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@smithy/core": "^3.33.3",
+                "@smithy/types": "^4.17.2",
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
+        "node_modules/@smithy/types": {
+            "version": "4.17.2",
+            "resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.17.2.tgz",
+            "integrity": "sha512-FOKpVZob9MPTn2znRzGrnsMHv7BOsKVw3XiP/cOyYLDVZ9qKp4nifIiSCuUU/fIj5Vu0UOAxCFr+qRAtG0NUkA==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "dependencies": {
+                "tslib": "^2.6.2"
+            },
+            "engines": {
+                "node": ">=18.0.0"
+            }
+        },
         "node_modules/@sveltejs/acorn-typescript": {
             "version": "1.0.13",
             "resolved": "https://registry.npmjs.org/@sveltejs/acorn-typescript/-/acorn-typescript-1.0.13.tgz",
@@ -3825,6 +4239,13 @@
             "engines": {
                 "node": "*"
             }
+        },
+        "node_modules/bowser": {
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/bowser/-/bowser-2.14.1.tgz",
+            "integrity": "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/braces": {
             "version": "3.0.3",
@@ -7964,8 +8385,7 @@
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
             "dev": true,
-            "license": "0BSD",
-            "optional": true
+            "license": "0BSD"
         },
         "node_modules/tsx": {
             "version": "4.23.12",

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
         "sortablejs": "^1.15.7"
     },
     "devDependencies": {
+        "@aws-sdk/client-s3": "^3.1121.0",
         "@biomejs/biome": "2.0.4",
         "@types/chrome": "^0.2.7",
         "@types/jsdom": "^28.0.3",

--- a/tooling/build-and-patch.ts
+++ b/tooling/build-and-patch.ts
@@ -1,15 +1,19 @@
-import { execSync } from "child_process";
-import { readFileSync, writeFileSync } from "fs";
-import { join } from "path";
+import { execFileSync } from "node:child_process";
+import { readFileSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { SOURCEMAPS_STAGING_ROOT } from "./sourcemap-utils.js";
 
 const browsers = ["chrome", "edge", "firefox"];
 
 try {
-  execSync("rm -rf sourcemaps_for_upload", { stdio: "inherit" });
+  rmSync(SOURCEMAPS_STAGING_ROOT, { recursive: true, force: true });
 
   for (const browser of browsers) {
     console.log(`Building for ${browser}...`);
-    execSync(`extension build --browser ${browser} --polyfill`, { stdio: "inherit" });
+    execFileSync("extension", ["build", "--browser", browser, "--polyfill"], {
+      stdio: "inherit",
+      env: { ...process.env, SOURCEMAPS_ENABLED: "true" },
+    });
 
     if (browser === "edge") {
       console.log("Removing key field from manifest.json for edge...");
@@ -19,17 +23,13 @@ try {
       writeFileSync(manifestPath, JSON.stringify(manifest, null, 2));
     }
 
-    console.log(`Copying sourcemaps for ${browser}...`);
-    execSync(`mkdir -p sourcemaps_for_upload/${browser}`, { stdio: "inherit" });
-    execSync(`find dist/${browser} -name '*.map' -exec cp {} sourcemaps_for_upload/${browser} \\; -delete`, {
-      stdio: "inherit",
-    });
+    console.log(`Staging and patching sourcemaps for ${browser}...`);
+    execFileSync("tsx", ["tooling/patch-sourcemaps.ts", browser], { stdio: "inherit" });
+  }
 
-    console.log(`Patching sourcemaps for ${browser}...`);
-    execSync(`tsx tooling/patch-sourcemaps.ts ${browser}`, { stdio: "inherit" });
-
-    console.log(`Uploading sourcemaps for ${browser}...`);
-    execSync(`tsx tooling/upload-sourcemaps.ts ${browser}`, { stdio: "inherit" });
+  for (const browser of browsers) {
+    console.log(`Uploading sourcemaps for ${browser} directly to R2...`);
+    execFileSync("tsx", ["tooling/upload-sourcemaps.ts", browser], { stdio: "inherit" });
   }
 } catch (error) {
   console.error("Build and patch process failed:", error);

--- a/tooling/patch-sourcemaps.ts
+++ b/tooling/patch-sourcemaps.ts
@@ -1,6 +1,4 @@
-import fs from "fs";
-import path from "path";
-import { execSync } from "child_process";
+import { DEFAULT_SOURCEMAPS_BASE_URL, getSourcemapBuildIdentity, stageBrowserSourcemaps } from "./sourcemap-utils.js";
 
 const browser = process.argv[2];
 if (!browser) {
@@ -8,35 +6,12 @@ if (!browser) {
   process.exit(1);
 }
 
-const packageJson = JSON.parse(fs.readFileSync("./package.json", "utf-8"));
-const version = packageJson.version;
-const gitHash = execSync("git rev-parse --short HEAD").toString().trim();
-const SOURCEMAPS_BASE_URL = process.env.SOURCEMAPS_BASE_URL || "https://better-lyrics-sourcemaps.dacubeking.com";
-
-function findFiles(dir: string, extension: string, fileList: string[] = []) {
-  const files = fs.readdirSync(dir);
-
-  files.forEach(file => {
-    const filePath = path.join(dir, file);
-    const stat = fs.statSync(filePath);
-
-    if (stat.isDirectory()) {
-      findFiles(filePath, extension, fileList);
-    } else if (path.extname(file) === extension) {
-      fileList.push(filePath);
-    }
-  });
-
-  return fileList;
-}
-
-const jsFiles = findFiles(`./dist/${browser}`, ".js");
-
-jsFiles.forEach(file => {
-  const fileName = path.basename(file);
-  const sourceMappingURL = `\n//# sourceMappingURL=${SOURCEMAPS_BASE_URL}/${browser}/v${version}-${gitHash}/${fileName}.map`;
-  let fileString = fs.readFileSync(file, "utf-8");
-  // Replace the sourceMappingURL at the bottom:
-  fileString = fileString.replace(/\/\/# sourceMappingURL=.*\.map$/, sourceMappingURL);
-  fs.writeFileSync(file, fileString);
+const identity = getSourcemapBuildIdentity();
+const staged = stageBrowserSourcemaps({
+  browser,
+  versionWithHash: identity.versionWithHash,
+  baseUrl: process.env.SOURCEMAPS_BASE_URL || DEFAULT_SOURCEMAPS_BASE_URL,
+  keyPrefix: process.env.SOURCEMAPS_KEY_PREFIX,
 });
+
+console.log(`Staged and patched ${staged.length} sourcemap(s) for ${browser}.`);

--- a/tooling/run-selfchecks.ts
+++ b/tooling/run-selfchecks.ts
@@ -5,11 +5,14 @@ import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const repoRoot = join(__dirname, "..");
-const srcDir = join(repoRoot, "src");
+const selfcheckDirs = [join(repoRoot, "src"), join(repoRoot, "tooling")];
 
-const files = readdirSync(srcDir, { recursive: true, encoding: "utf8" })
-  .filter(entry => entry.endsWith(".selfcheck.ts"))
-  .map(entry => join(srcDir, entry))
+const files = selfcheckDirs
+  .flatMap(dir =>
+    readdirSync(dir, { recursive: true, encoding: "utf8" })
+      .filter(entry => entry.endsWith(".selfcheck.ts"))
+      .map(entry => join(dir, entry))
+  )
   .sort();
 
 if (files.length === 0) {

--- a/tooling/sourcemap-pipeline.selfcheck.ts
+++ b/tooling/sourcemap-pipeline.selfcheck.ts
@@ -1,0 +1,64 @@
+import assert from "node:assert/strict";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { stageBrowserSourcemaps } from "./sourcemap-utils.js";
+
+const fixtureRoot = mkdtempSync(path.join(tmpdir(), "better-lyrics-sourcemaps-"));
+const distRoot = path.join(fixtureRoot, "dist");
+const stagingRoot = path.join(fixtureRoot, "staged");
+const browserRoot = path.join(distRoot, "chrome");
+
+function writeFixture(relativePath: string, contents: string): void {
+  const filePath = path.join(browserRoot, relativePath);
+  mkdirSync(path.dirname(filePath), { recursive: true });
+  writeFileSync(filePath, contents);
+}
+
+try {
+  const map = JSON.stringify({ version: 3, sources: ["source.ts"], names: [], mappings: "" });
+  writeFixture("action/index.js", "console.log('action');\n//# sourceMappingURL=index.js.map\n");
+  writeFixture("action/index.js.map", map);
+  writeFixture("options/index.js", "console.log('options');\n//# sourceMappingURL=index.js.map\n");
+  writeFixture("options/index.js.map", map);
+  writeFixture("styles/main.css", "body {}\n/*# sourceMappingURL=main.css.map */\n");
+  writeFixture("styles/main.css.map", map);
+
+  const staged = stageBrowserSourcemaps({
+    browser: "chrome",
+    versionWithHash: "1.2.3.4-dev (abc1234)-abc1234",
+    baseUrl: "https://sourcemaps.example.test/",
+    keyPrefix: "diagnostics/prefix",
+    distRoot,
+    stagingRoot,
+  });
+
+  assert.equal(staged.length, 3);
+  assert.deepEqual(staged.map(item => item.relativeMapPath).sort(), [
+    "action/index.js.map",
+    "options/index.js.map",
+    "styles/main.css.map",
+  ]);
+
+  for (const relativePath of ["action/index.js.map", "options/index.js.map", "styles/main.css.map"]) {
+    assert.equal(existsSync(path.join(browserRoot, relativePath)), false);
+    assert.equal(existsSync(path.join(stagingRoot, "chrome", relativePath)), true);
+  }
+
+  assert.match(
+    readFileSync(path.join(browserRoot, "action/index.js"), "utf8"),
+    /diagnostics\/prefix\/chrome\/v1\.2\.3\.4-dev%20\(abc1234\)-abc1234\/action\/index\.js\.map/
+  );
+  assert.match(
+    readFileSync(path.join(browserRoot, "options/index.js"), "utf8"),
+    /diagnostics\/prefix\/chrome\/v1\.2\.3\.4-dev%20\(abc1234\)-abc1234\/options\/index\.js\.map/
+  );
+  assert.match(
+    readFileSync(path.join(browserRoot, "styles/main.css"), "utf8"),
+    /diagnostics\/prefix\/chrome\/v1\.2\.3\.4-dev%20\(abc1234\)-abc1234\/styles\/main\.css\.map/
+  );
+
+  console.log("Sourcemap staging self-check passed");
+} finally {
+  rmSync(fixtureRoot, { recursive: true, force: true });
+}

--- a/tooling/sourcemap-utils.ts
+++ b/tooling/sourcemap-utils.ts
@@ -1,0 +1,158 @@
+import { execFileSync } from "node:child_process";
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+
+export const DEFAULT_SOURCEMAPS_BASE_URL = "https://better-lyrics-sourcemaps.dacubeking.com";
+export const DEFAULT_SOURCEMAPS_BUCKET = "better-lyrics-sourcemaps";
+export const SOURCEMAPS_STAGING_ROOT = "sourcemaps_for_upload";
+
+export interface SourcemapBuildIdentity {
+  version: string;
+  gitHash: string;
+  versionWithHash: string;
+}
+
+export interface StagedSourcemap {
+  sourcePath: string;
+  stagedPath: string;
+  relativeMapPath: string;
+  objectKey: string;
+  publicUrl: string;
+}
+
+export function findFiles(dir: string): string[] {
+  const files: string[] = [];
+
+  for (const entry of readdirSync(dir)) {
+    const filePath = path.join(dir, entry);
+    if (statSync(filePath).isDirectory()) {
+      files.push(...findFiles(filePath));
+    } else {
+      files.push(filePath);
+    }
+  }
+
+  return files;
+}
+
+export function getSourcemapBuildIdentity(repoRoot = process.cwd()): SourcemapBuildIdentity {
+  const packageJson = JSON.parse(readFileSync(path.join(repoRoot, "package.json"), "utf8")) as { version?: unknown };
+  if (typeof packageJson.version !== "string" || packageJson.version.length === 0) {
+    throw new Error("package.json must contain a non-empty version string");
+  }
+
+  const gitHash = execFileSync("git", ["rev-parse", "--short", "HEAD"], {
+    cwd: repoRoot,
+    encoding: "utf8",
+  }).trim();
+
+  return {
+    version: packageJson.version,
+    gitHash,
+    versionWithHash: `${packageJson.version}-${gitHash}`,
+  };
+}
+
+function normalizeKeyPart(value: string): string {
+  return value.replaceAll("\\", "/").replace(/^\/+|\/+$/g, "");
+}
+
+export function getSourcemapObjectKey(
+  browser: string,
+  versionWithHash: string,
+  relativeMapPath: string,
+  keyPrefix = ""
+): string {
+  const parts = [keyPrefix, browser, `v${versionWithHash}`, relativeMapPath].map(normalizeKeyPart).filter(Boolean);
+  const key = parts.join("/");
+
+  if (key.includes("../") || key.startsWith("/")) {
+    throw new Error(`Invalid sourcemap object key: ${key}`);
+  }
+
+  return key;
+}
+
+export function getPublicSourcemapUrl(baseUrl: string, objectKey: string): string {
+  const normalizedBaseUrl = `${baseUrl.replace(/\/+$/, "")}/`;
+  const encodedKey = objectKey
+    .split("/")
+    .map(segment => encodeURIComponent(segment))
+    .join("/");
+  return new URL(encodedKey, normalizedBaseUrl).toString();
+}
+
+function replaceSourcemapReference(sourcePath: string, publicUrl: string): void {
+  const extension = path.extname(sourcePath);
+  const source = readFileSync(sourcePath, "utf8");
+
+  if (extension === ".js") {
+    const withoutReference = source.replace(/\s*\/\/[#@]\s*sourceMappingURL=.*?\s*$/s, "").trimEnd();
+    writeFileSync(sourcePath, `${withoutReference}\n\n//# sourceMappingURL=${publicUrl}\n`);
+    return;
+  }
+
+  if (extension === ".css") {
+    const withoutReference = source.replace(/\s*\/\*[#@]\s*sourceMappingURL=.*?\*\/\s*$/s, "").trimEnd();
+    writeFileSync(sourcePath, `${withoutReference}\n\n/*# sourceMappingURL=${publicUrl} */\n`);
+    return;
+  }
+
+  throw new Error(`Unsupported sourcemap source type for ${sourcePath}`);
+}
+
+export function stageBrowserSourcemaps(options: {
+  browser: string;
+  versionWithHash: string;
+  baseUrl: string;
+  keyPrefix?: string;
+  distRoot?: string;
+  stagingRoot?: string;
+}): StagedSourcemap[] {
+  const distRoot = options.distRoot ?? "dist";
+  const stagingRoot = options.stagingRoot ?? SOURCEMAPS_STAGING_ROOT;
+  const browserDistDir = path.resolve(distRoot, options.browser);
+  const browserStagingDir = path.resolve(stagingRoot, options.browser);
+
+  if (!existsSync(browserDistDir)) {
+    throw new Error(`Build directory does not exist: ${browserDistDir}`);
+  }
+
+  const mapPaths = findFiles(browserDistDir).filter(filePath => filePath.endsWith(".map"));
+  if (mapPaths.length === 0) {
+    throw new Error(`No sourcemaps found for ${options.browser}`);
+  }
+
+  return mapPaths.map(mapPath => {
+    const relativeMapPath = path.relative(browserDistDir, mapPath).replaceAll(path.sep, "/");
+    const sourcePath = mapPath.slice(0, -".map".length);
+    if (!existsSync(sourcePath)) {
+      throw new Error(`Sourcemap source file does not exist: ${sourcePath}`);
+    }
+
+    const objectKey = getSourcemapObjectKey(
+      options.browser,
+      options.versionWithHash,
+      relativeMapPath,
+      options.keyPrefix
+    );
+    const publicUrl = getPublicSourcemapUrl(options.baseUrl, objectKey);
+    const stagedPath = path.join(browserStagingDir, ...relativeMapPath.split("/"));
+
+    replaceSourcemapReference(sourcePath, publicUrl);
+    mkdirSync(path.dirname(stagedPath), { recursive: true });
+    copyFileSync(mapPath, stagedPath);
+    unlinkSync(mapPath);
+
+    return { sourcePath, stagedPath, relativeMapPath, objectKey, publicUrl };
+  });
+}

--- a/tooling/upload-sourcemaps.ts
+++ b/tooling/upload-sourcemaps.ts
@@ -1,80 +1,199 @@
-import { execSync } from "child_process";
-import fs from "fs";
-import path from "path";
+import { createHash } from "node:crypto";
+import { readFileSync } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { constants as zlibConstants, gzipSync } from "node:zlib";
+import { HeadObjectCommand, PutObjectCommand, S3Client } from "@aws-sdk/client-s3";
+import {
+  DEFAULT_SOURCEMAPS_BUCKET,
+  findFiles,
+  getSourcemapBuildIdentity,
+  getSourcemapObjectKey,
+  SOURCEMAPS_STAGING_ROOT,
+} from "./sourcemap-utils.js";
 
-const browser = process.argv[2];
-if (!browser) {
-  console.error("Browser argument is missing.");
-  process.exit(1);
+const DEFAULT_UPLOAD_CONCURRENCY = 4;
+const DEFAULT_MAX_ATTEMPTS = 5;
+const REQUEST_TIMEOUT_MS = 60_000;
+
+interface UploadConfig {
+  endpoint: string;
+  bucket: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+  keyPrefix: string;
+  concurrency: number;
+  maxAttempts: number;
 }
 
-const SOURCEMAPS_BASE_URL = process.env.SOURCEMAPS_BASE_URL || "https://better-lyrics-sourcemaps.dacubeking.com";
-const SOURCEMAPS_API_KEY = process.env.SOURCEMAPS_API_KEY;
-
-if (!SOURCEMAPS_API_KEY) {
-  console.error("Missing SOURCEMAPS_API_KEY environment variable.");
-  process.exit(1);
+interface PreparedSourcemap {
+  objectKey: string;
+  compressedBody: Buffer;
+  uncompressedSha256: string;
 }
 
-const packageJson = JSON.parse(fs.readFileSync("./package.json", "utf-8"));
-const version = packageJson.version;
-const gitHash = execSync("git rev-parse --short HEAD").toString().trim();
-const versionWithHash = `${version}-${gitHash}`;
+function requireEnvironmentVariable(name: string): string {
+  const value = process.env[name]?.trim();
+  if (!value) {
+    throw new Error(`Missing ${name} environment variable.`);
+  }
+  return value;
+}
 
-async function uploadFile(filePath: string) {
-  const fileName = path.basename(filePath);
-  const fileContent = fs.readFileSync(filePath);
+function parsePositiveInteger(value: string | undefined, fallback: number, name: string): number {
+  if (!value) return fallback;
+  const parsed = Number.parseInt(value, 10);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`${name} must be a positive integer.`);
+  }
+  return parsed;
+}
 
-  // Construct the URL: /<browser>/v<version>-<hash>/<filename>
-  const url = `${SOURCEMAPS_BASE_URL}/${browser}/v${versionWithHash}/${fileName}`;
+export function getUploadConfig(): UploadConfig {
+  const endpointUrl = new URL(requireEnvironmentVariable("R2_ENDPOINT"));
+  if (endpointUrl.pathname !== "/") {
+    throw new Error("R2_ENDPOINT must be the account endpoint without a bucket path.");
+  }
 
-  try {
-    const response = await fetch(url, {
-      method: "PUT",
-      headers: {
-        "Content-Type": "application/json",
-        "x-auth-token": SOURCEMAPS_API_KEY!,
-        "User-Agent": "better-lyrics-ci/1.0",
+  return {
+    endpoint: endpointUrl.toString().replace(/\/$/, ""),
+    bucket: process.env.R2_BUCKET?.trim() || DEFAULT_SOURCEMAPS_BUCKET,
+    accessKeyId: requireEnvironmentVariable("R2_ACCESS_KEY_ID"),
+    secretAccessKey: requireEnvironmentVariable("R2_SECRET_ACCESS_KEY"),
+    keyPrefix: process.env.SOURCEMAPS_KEY_PREFIX?.trim() || "",
+    concurrency: parsePositiveInteger(
+      process.env.SOURCEMAPS_UPLOAD_CONCURRENCY,
+      DEFAULT_UPLOAD_CONCURRENCY,
+      "SOURCEMAPS_UPLOAD_CONCURRENCY"
+    ),
+    maxAttempts: parsePositiveInteger(
+      process.env.SOURCEMAPS_MAX_ATTEMPTS,
+      DEFAULT_MAX_ATTEMPTS,
+      "SOURCEMAPS_MAX_ATTEMPTS"
+    ),
+  };
+}
+
+export function createR2Client(config: UploadConfig): S3Client {
+  return new S3Client({
+    region: "auto",
+    endpoint: config.endpoint,
+    credentials: {
+      accessKeyId: config.accessKeyId,
+      secretAccessKey: config.secretAccessKey,
+    },
+    maxAttempts: config.maxAttempts,
+    retryMode: "standard",
+  });
+}
+
+function prepareSourcemap(filePath: string, objectKey: string): PreparedSourcemap {
+  const body = readFileSync(filePath);
+  const parsed = JSON.parse(body.toString("utf8").replace(/^\uFEFF/, "")) as { version?: unknown };
+  if (parsed.version !== 3) {
+    throw new Error(`${filePath} is not a version 3 sourcemap.`);
+  }
+
+  return {
+    objectKey,
+    compressedBody: gzipSync(body, { level: zlibConstants.Z_BEST_COMPRESSION }),
+    uncompressedSha256: createHash("sha256").update(body).digest("hex"),
+  };
+}
+
+async function uploadSourcemap(s3: S3Client, config: UploadConfig, sourcemap: PreparedSourcemap): Promise<void> {
+  await s3.send(
+    new PutObjectCommand({
+      Bucket: config.bucket,
+      Key: sourcemap.objectKey,
+      Body: sourcemap.compressedBody,
+      ContentType: "application/json",
+      ContentEncoding: "gzip",
+      CacheControl: "public, max-age=2592000, immutable",
+      Metadata: {
+        "uncompressed-sha256": sourcemap.uncompressedSha256,
       },
-      body: fileContent,
-    });
+    }),
+    { abortSignal: AbortSignal.timeout(REQUEST_TIMEOUT_MS) }
+  );
 
-    if (!response.ok) {
-      throw new Error(
-        `Failed to upload ${fileName}: ${response.status} ${response.statusText} - ${await response.text()}`
-      );
+  const head = await s3.send(new HeadObjectCommand({ Bucket: config.bucket, Key: sourcemap.objectKey }), {
+    abortSignal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+  });
+
+  if (head.ContentLength !== sourcemap.compressedBody.byteLength) {
+    throw new Error(`R2 verification failed for ${sourcemap.objectKey}: compressed size does not match.`);
+  }
+  if (head.ContentEncoding !== "gzip" || head.ContentType !== "application/json") {
+    throw new Error(`R2 verification failed for ${sourcemap.objectKey}: HTTP metadata does not match.`);
+  }
+  if (head.Metadata?.["uncompressed-sha256"] !== sourcemap.uncompressedSha256) {
+    throw new Error(`R2 verification failed for ${sourcemap.objectKey}: source hash does not match.`);
+  }
+
+  console.log(`Uploaded and verified ${sourcemap.objectKey} (${sourcemap.compressedBody.byteLength} bytes gzip).`);
+}
+
+async function runWithConcurrency<T>(items: T[], concurrency: number, task: (item: T) => Promise<void>): Promise<void> {
+  let nextIndex = 0;
+  const errors: Error[] = [];
+
+  async function worker(): Promise<void> {
+    while (nextIndex < items.length) {
+      const item = items[nextIndex++];
+      try {
+        await task(item);
+      } catch (error) {
+        errors.push(error instanceof Error ? error : new Error(String(error)));
+      }
     }
+  }
 
-    console.log(`Successfully uploaded ${fileName} to API.`);
-  } catch (err) {
-    console.error(`Error uploading ${fileName}:`, err);
-    process.exit(1);
+  await Promise.all(Array.from({ length: Math.min(concurrency, items.length) }, () => worker()));
+
+  if (errors.length > 0) {
+    throw new AggregateError(errors, `${errors.length} sourcemap upload(s) failed.`);
   }
 }
 
-function findFiles(dir: string, fileList: string[] = []) {
-  const files = fs.readdirSync(dir);
+export async function uploadBrowserSourcemaps(browser: string, config = getUploadConfig()): Promise<number> {
+  const identity = getSourcemapBuildIdentity();
+  const browserStagingDir = path.resolve(SOURCEMAPS_STAGING_ROOT, browser);
+  const sourcemapFiles = findFiles(browserStagingDir).filter(filePath => filePath.endsWith(".map"));
+  if (sourcemapFiles.length === 0) {
+    throw new Error(`No staged sourcemaps found for ${browser}.`);
+  }
 
-  files.forEach(file => {
-    const filePath = path.join(dir, file);
-    const stat = fs.statSync(filePath);
-
-    if (stat.isDirectory()) {
-      findFiles(filePath, fileList);
-    } else {
-      fileList.push(filePath);
-    }
+  const prepared = sourcemapFiles.map(filePath => {
+    const relativeMapPath = path.relative(browserStagingDir, filePath).replaceAll(path.sep, "/");
+    const objectKey = getSourcemapObjectKey(browser, identity.versionWithHash, relativeMapPath, config.keyPrefix);
+    return prepareSourcemap(filePath, objectKey);
   });
 
-  return fileList;
+  const s3 = createR2Client(config);
+  try {
+    await runWithConcurrency(prepared, config.concurrency, sourcemap => uploadSourcemap(s3, config, sourcemap));
+  } finally {
+    s3.destroy();
+  }
+
+  return prepared.length;
 }
 
-const sourcemapFiles = findFiles(`./sourcemaps_for_upload/${browser}`);
-if (sourcemapFiles.length === 0) {
-  console.warn(`Warning: No sourcemap files found for ${browser}`);
+async function main(): Promise<void> {
+  const browser = process.argv[2];
+  if (!browser) {
+    throw new Error("Browser argument is missing.");
+  }
+
+  const count = await uploadBrowserSourcemaps(browser);
+  console.log(`Uploaded ${count} sourcemap(s) for ${browser}.`);
 }
 
-await Promise.all(sourcemapFiles.map(uploadFile)).catch(e => {
-  console.error("Upload Failed", e);
-  process.exit(1);
-});
+const isMainModule = process.argv[1] && path.resolve(process.argv[1]) === fileURLToPath(import.meta.url);
+if (isMainModule) {
+  main().catch(error => {
+    console.error(error);
+    process.exitCode = 1;
+  });
+}


### PR DESCRIPTION
## Summary

- upload sourcemaps directly to Cloudflare R2 through its S3-compatible API
- gzip every object and verify the uploaded size, encoding, content type, and source hash with `HeadObject`
- add bounded concurrency, SDK retries, and request timeouts
- preserve nested output paths so same-named bundles cannot overwrite each other
- patch both JavaScript and CSS sourcemap references to their final public URLs
- explicitly generate sourcemaps for production release builds, stage every browser first, then upload
- remove the Cloudflare bypass action and Worker upload API dependency from CI
- add a sourcemap pipeline self-check and include tooling in Knip analysis

## Retention

Objects remain governed by the bucket's existing 30-day R2 lifecycle policy; this change does not extend retention.

## Verification

- `npm run selfcheck`
- `npx tsc --noEmit -p tooling/tsconfig.json`
- `npm run typecheck`
- `npm run knip`
- parsed all modified workflow YAML files
- `npm audit --omit=dev` (0 vulnerabilities)
- live R2 round-trip smoke test: uploaded and verified 60 generated maps across Chrome, Edge, and Firefox, fetched one through the public endpoint to verify decompression, then deleted all test objects
- live spaced-key smoke test matching nightly version formatting, followed by cleanup
