### PR TITLE
chore: bump @braccato/parsers to 0.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
             "license": "GPL-3.0",
             "dependencies": {
                 "@braccato/core": "1.3.0",
-                "@braccato/parsers": "0.2.0",
+                "@braccato/parsers": "0.2.1",
                 "@codemirror/autocomplete": "^6.20.3",
                 "@codemirror/commands": "^6.11.0",
                 "@codemirror/lint": "^6.9.7",
@@ -661,9 +661,9 @@
             }
         },
         "node_modules/@braccato/parsers": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/@braccato/parsers/-/parsers-0.2.0.tgz",
-            "integrity": "sha512-vHdNv7t1DQnKw7tWTc/AfrGsK/nHLiihqM/xLm0gbTE+iN9WNKsupQ/jAeheQHaQQzZNCYnZicnXb5cxiXjqwg==",
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/@braccato/parsers/-/parsers-0.2.1.tgz",
+            "integrity": "sha512-Yzmj6KlPkGd2NXMQUSvm9NV2oZuJrGwf2xk5aOXCOazty6wgivXrOqtXQoOejAkzgiCUpnDeNFza6wd8rYHrow==",
             "license": "MIT",
             "dependencies": {
                 "@braccato/types": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     },
     "dependencies": {
         "@braccato/core": "1.3.0",
-        "@braccato/parsers": "0.2.0",
+        "@braccato/parsers": "0.2.1",
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/commands": "^6.11.0",
         "@codemirror/lint": "^6.9.7",


### PR DESCRIPTION
Picks up @braccato/parsers 0.2.1, which decodes HTML entities (`&rsquo;`, `&mdash;`, `&hellip;`, `&amp;`, numeric refs) in TTML lyric text instead of leaving them raw. No API changes; exact pin moved 0.2.0 -> 0.2.1 with the lockfile refreshed.