### PR TITLE
chore: bump rics and codemirror-lang-rics to 0.3.22

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,12 +20,12 @@
                 "@formkit/auto-animate": "^0.10.0",
                 "@fsegurai/codemirror-theme-material-dark": "^6.2.5",
                 "@plasmohq/edge-addons-api": "^2.0.0",
-                "codemirror-lang-rics": "^0.3.21",
+                "codemirror-lang-rics": "^0.3.22",
                 "dompurify": "^3.4.14",
                 "fast-xml-parser": "^5.10.1",
                 "fflate": "^0.8.3",
                 "marked": "^18.0.10",
-                "rics": "^0.3.21",
+                "rics": "^0.3.22",
                 "sortablejs": "^1.15.7"
             },
             "devDependencies": {
@@ -4510,12 +4510,12 @@
             }
         },
         "node_modules/codemirror-lang-rics": {
-            "version": "0.3.21",
-            "resolved": "https://registry.npmjs.org/codemirror-lang-rics/-/codemirror-lang-rics-0.3.21.tgz",
-            "integrity": "sha512-oftS9y6mzWSSX01k70Ni0B5ykBvNzyK9d6oKaf88QdJp+bgYKth4fSULP99VoDvTu+mSmbiTeWLqAGMvDPW7IQ==",
+            "version": "0.3.22",
+            "resolved": "https://registry.npmjs.org/codemirror-lang-rics/-/codemirror-lang-rics-0.3.22.tgz",
+            "integrity": "sha512-cdY78PPkwV5VHzZgFAEDjF0OwruUAU3mBJsZNfsC829AIExWyysXc6sW9dv6K3E4/tTGE6irNFl8ZclLtcBeRg==",
             "license": "MIT",
             "dependencies": {
-                "rics": "0.3.21"
+                "rics": "0.3.22"
             },
             "engines": {
                 "node": ">=18.0.0"
@@ -7910,9 +7910,9 @@
             }
         },
         "node_modules/rics": {
-            "version": "0.3.21",
-            "resolved": "https://registry.npmjs.org/rics/-/rics-0.3.21.tgz",
-            "integrity": "sha512-u9mbIsUhzJ2Smhw3IqrjP6K6M3mv9izrT+a43w1+n5Q8Sdj8LI1M7u66/yuk4EeQlGj29L7KAVbcV8CgxbCa8w==",
+            "version": "0.3.22",
+            "resolved": "https://registry.npmjs.org/rics/-/rics-0.3.22.tgz",
+            "integrity": "sha512-SCh371T5mETy7vl/8I3f3sv9HMGOjR3Y3D7Ay1eGlaGJhY+O8zEU8EsyWK4tBGIU+dO/huS2abCnnvE57d/1JQ==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.0.0"

--- a/package.json
+++ b/package.json
@@ -53,12 +53,12 @@
         "@formkit/auto-animate": "^0.10.0",
         "@fsegurai/codemirror-theme-material-dark": "^6.2.5",
         "@plasmohq/edge-addons-api": "^2.0.0",
-        "codemirror-lang-rics": "^0.3.21",
+        "codemirror-lang-rics": "^0.3.22",
         "dompurify": "^3.4.14",
         "fast-xml-parser": "^5.10.1",
         "fflate": "^0.8.3",
         "marked": "^18.0.10",
-        "rics": "^0.3.21",
+        "rics": "^0.3.22",
         "sortablejs": "^1.15.7"
     },
     "devDependencies": {


### PR DESCRIPTION
Bump rics and codemirror-lang-rics to 0.3.22 for the block-comment fix: comments holding an apostrophe or a brace inside @if, @mixin, @for, or @each no longer break the block.
